### PR TITLE
Add support for Environment Variables in Slack commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ Other, optional parameters:
 **NOTE**: at least either `branch` or `workflow` have to be specified, and of course
 you can specify both if you want to. You're free to specify any number of optional parameters.
 
-An example with all parameters included: `workflow: primary|b: master|tag: v1.0|commit:eee55509f16e7715bdb43308bb55e8736da4e21e|m: start my build!`
+You can also send environment variables that will be available in your workflow with the format: `env[KEY1]:value1|ENV[KEY2]:value2`
+
+An example with all parameters included: `workflow: primary|b: master|tag: v1.0|commit:eee55509f16e7715bdb43308bb55e8736da4e21e|m: start my build!|ENV[DEVICE_NAME]:iPhone 6S|ENV[DEVICE_UDID]:82667b4079914d4aabed9c216620da5dedab630a`
 
 
 ## How to compile & run the server

--- a/bitriseapi/bitriseapi.go
+++ b/bitriseapi/bitriseapi.go
@@ -12,14 +12,22 @@ import (
 	"time"
 )
 
+// EnvironmentItem ...
+type EnvironmentItem struct {
+	Name        string 	`json:"mapped_to,omitempty"`
+	Value       string 	`json:"value,omitempty"`
+	IsExpand    bool 	`json:"is_expand,omitempty"`
+}
+
 // BuildParamsModel ...
 type BuildParamsModel struct {
-	CommitHash    string `json:"commit_hash,omitempty"`
-	CommitMessage string `json:"commit_message,omitempty"`
-	Branch        string `json:"branch,omitempty"`
-	Tag           string `json:"tag,omitempty"`
-	PullRequestID *int   `json:"pull_request_id,omitempty"`
-	WorkflowID    string `json:"workflow_id,omitempty"`
+	CommitHash    string 			`json:"commit_hash,omitempty"`
+	CommitMessage string 			`json:"commit_message,omitempty"`
+	Branch        string 			`json:"branch,omitempty"`
+	Tag           string 			`json:"tag,omitempty"`
+	PullRequestID *int   			`json:"pull_request_id,omitempty"`
+	WorkflowID    string 			`json:"workflow_id,omitempty"`
+	Environments  []EnvironmentItem `json:"environments,omitempty"`
 }
 
 // TriggerAPIParamsModel ...

--- a/service/hook/gogs/gogs_test.go
+++ b/service/hook/gogs/gogs_test.go
@@ -1,157 +1,157 @@
 package gogs
 
 import (
-    "io/ioutil"
-    "net/http"
-    "strings"
-    "testing"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
 
-    "github.com/bitrise-io/bitrise-webhooks/bitriseapi"
-    "github.com/stretchr/testify/require"
+	"github.com/bitrise-io/bitrise-webhooks/bitriseapi"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_detectContentTypeAndEventID(t *testing.T) {
-    t.Log("Code Push event")
-    {
-        header := http.Header{
-            "X-Gogs-Event": {"push"},
-            "Content-Type":   {"application/json"},
-        }
-        contentType, eventID, err := detectContentTypeAndEventID(header)
-        require.NoError(t, err)
-        require.Equal(t, "application/json", contentType)
-        require.Equal(t, "push", eventID)
-    }
+	t.Log("Code Push event")
+	{
+		header := http.Header{
+			"X-Gogs-Event": {"push"},
+			"Content-Type": {"application/json"},
+		}
+		contentType, eventID, err := detectContentTypeAndEventID(header)
+		require.NoError(t, err)
+		require.Equal(t, "application/json", contentType)
+		require.Equal(t, "push", eventID)
+	}
 
-    t.Log("Missing X-Gogs-Event header")
-    {
-        header := http.Header{
-            "Content-Type": {"application/json"},
-        }
-        contentType, eventID, err := detectContentTypeAndEventID(header)
-        require.EqualError(t, err, "Issue with X-Gogs-Event Header: No value found in HEADER for the key: X-Gogs-Event")
-        require.Equal(t, "", contentType)
-        require.Equal(t, "", eventID)
-    }
+	t.Log("Missing X-Gogs-Event header")
+	{
+		header := http.Header{
+			"Content-Type": {"application/json"},
+		}
+		contentType, eventID, err := detectContentTypeAndEventID(header)
+		require.EqualError(t, err, "Issue with X-Gogs-Event Header: No value found in HEADER for the key: X-Gogs-Event")
+		require.Equal(t, "", contentType)
+		require.Equal(t, "", eventID)
+	}
 
-    t.Log("Missing Content-Type")
-    {
-        header := http.Header{
-            "X-Gogs-Event": {"push"},
-        }
-        contentType, eventID, err := detectContentTypeAndEventID(header)
-        require.EqualError(t, err, "Issue with Content-Type Header: No value found in HEADER for the key: Content-Type")
-        require.Equal(t, "", contentType)
-        require.Equal(t, "", eventID)
-    }
+	t.Log("Missing Content-Type")
+	{
+		header := http.Header{
+			"X-Gogs-Event": {"push"},
+		}
+		contentType, eventID, err := detectContentTypeAndEventID(header)
+		require.EqualError(t, err, "Issue with Content-Type Header: No value found in HEADER for the key: Content-Type")
+		require.Equal(t, "", contentType)
+		require.Equal(t, "", eventID)
+	}
 }
 
 func Test_transformCodePushEvent(t *testing.T) {
-    t.Log("Do Transform - single commit")
-    {
-        codePush := CodePushEventModel{
-            Secret:      "",
-            Ref:         "refs/heads/master",
-            CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
-            Commits: []CommitModel{
-                {
-                    CommitHash:    "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
-                    CommitMessage: `Response: omit the "failed_responses" array if empty`,
-                },
-            },
-        }
-        hookTransformResult := transformCodePushEvent(codePush)
-        require.NoError(t, hookTransformResult.Error)
-        require.False(t, hookTransformResult.ShouldSkip)
-        require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
-            {
-                BuildParams: bitriseapi.BuildParamsModel{
-                    CommitHash:    "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
-                    CommitMessage: `Response: omit the "failed_responses" array if empty`,
-                    Branch:        "master",
-                },
-            },
-        }, hookTransformResult.TriggerAPIParams)
-    }
+	t.Log("Do Transform - single commit")
+	{
+		codePush := CodePushEventModel{
+			Secret:      "",
+			Ref:         "refs/heads/master",
+			CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
+			Commits: []CommitModel{
+				{
+					CommitHash:    "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
+					CommitMessage: `Response: omit the "failed_responses" array if empty`,
+				},
+			},
+		}
+		hookTransformResult := transformCodePushEvent(codePush)
+		require.NoError(t, hookTransformResult.Error)
+		require.False(t, hookTransformResult.ShouldSkip)
+		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
+			{
+				BuildParams: bitriseapi.BuildParamsModel{
+					CommitHash:    "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
+					CommitMessage: `Response: omit the "failed_responses" array if empty`,
+					Branch:        "master",
+				},
+			},
+		}, hookTransformResult.TriggerAPIParams)
+	}
 
-    t.Log("Do Transform - multiple commits - CheckoutSHA match should trigger the build")
-    {
-        codePush := CodePushEventModel{
-            Secret:      "",
-            Ref:         "refs/heads/master",
-            CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
-            Commits: []CommitModel{
-                {
-                    CommitHash:    "7782203aaf0daabbd245ec0370c751eac6a4eb55",
-                    CommitMessage: `switch to three component versions`,
-                },
-                {
-                    CommitHash:    "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
-                    CommitMessage: `Response: omit the "failed_responses" array if empty`,
-                },
-                {
-                    CommitHash:    "ef77f9dba498f335e2e7078bdb52f9e11c214c58",
-                    CommitMessage: `get version : three component version`,
-                },
-            },
-        }
-        hookTransformResult := transformCodePushEvent(codePush)
-        require.NoError(t, hookTransformResult.Error)
-        require.False(t, hookTransformResult.ShouldSkip)
-        require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
-            {
-                BuildParams: bitriseapi.BuildParamsModel{
-                    CommitHash:    "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
-                    CommitMessage: `Response: omit the "failed_responses" array if empty`,
-                    Branch:        "master",
-                },
-            },
-        }, hookTransformResult.TriggerAPIParams)
-    }
+	t.Log("Do Transform - multiple commits - CheckoutSHA match should trigger the build")
+	{
+		codePush := CodePushEventModel{
+			Secret:      "",
+			Ref:         "refs/heads/master",
+			CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
+			Commits: []CommitModel{
+				{
+					CommitHash:    "7782203aaf0daabbd245ec0370c751eac6a4eb55",
+					CommitMessage: `switch to three component versions`,
+				},
+				{
+					CommitHash:    "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
+					CommitMessage: `Response: omit the "failed_responses" array if empty`,
+				},
+				{
+					CommitHash:    "ef77f9dba498f335e2e7078bdb52f9e11c214c58",
+					CommitMessage: `get version : three component version`,
+				},
+			},
+		}
+		hookTransformResult := transformCodePushEvent(codePush)
+		require.NoError(t, hookTransformResult.Error)
+		require.False(t, hookTransformResult.ShouldSkip)
+		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
+			{
+				BuildParams: bitriseapi.BuildParamsModel{
+					CommitHash:    "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
+					CommitMessage: `Response: omit the "failed_responses" array if empty`,
+					Branch:        "master",
+				},
+			},
+		}, hookTransformResult.TriggerAPIParams)
+	}
 
-    t.Log("No commit matches CheckoutSHA")
-    {
-        codePush := CodePushEventModel{
-            Secret:      "",
-            Ref:         "refs/heads/master",
-            CheckoutSHA: "checkout-sha",
-            Commits: []CommitModel{
-                {
-                    CommitHash:    "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
-                    CommitMessage: `Response: omit the "failed_responses" array if empty`,
-                },
-            },
-        }
-        hookTransformResult := transformCodePushEvent(codePush)
-        require.EqualError(t, hookTransformResult.Error, "The commit specified by 'after' was not included in the 'commits' array - no match found")
-        require.False(t, hookTransformResult.ShouldSkip)
-        require.Nil(t, hookTransformResult.TriggerAPIParams)
-    }
+	t.Log("No commit matches CheckoutSHA")
+	{
+		codePush := CodePushEventModel{
+			Secret:      "",
+			Ref:         "refs/heads/master",
+			CheckoutSHA: "checkout-sha",
+			Commits: []CommitModel{
+				{
+					CommitHash:    "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
+					CommitMessage: `Response: omit the "failed_responses" array if empty`,
+				},
+			},
+		}
+		hookTransformResult := transformCodePushEvent(codePush)
+		require.EqualError(t, hookTransformResult.Error, "The commit specified by 'after' was not included in the 'commits' array - no match found")
+		require.False(t, hookTransformResult.ShouldSkip)
+		require.Nil(t, hookTransformResult.TriggerAPIParams)
+	}
 
-    t.Log("Not a head ref")
-    {
-        codePush := CodePushEventModel{
-            Secret:      "",
-            Ref:         "refs/not/head",
-            CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
-            Commits: []CommitModel{
-                {
-                    CommitHash:    "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
-                    CommitMessage: `Response: omit the "failed_responses" array if empty`,
-                },
-            },
-        }
-        hookTransformResult := transformCodePushEvent(codePush)
-        require.True(t, hookTransformResult.ShouldSkip)
-        require.EqualError(t, hookTransformResult.Error, "Ref (refs/not/head) is not a head ref")
-        require.Nil(t, hookTransformResult.TriggerAPIParams)
-    }
+	t.Log("Not a head ref")
+	{
+		codePush := CodePushEventModel{
+			Secret:      "",
+			Ref:         "refs/not/head",
+			CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
+			Commits: []CommitModel{
+				{
+					CommitHash:    "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
+					CommitMessage: `Response: omit the "failed_responses" array if empty`,
+				},
+			},
+		}
+		hookTransformResult := transformCodePushEvent(codePush)
+		require.True(t, hookTransformResult.ShouldSkip)
+		require.EqualError(t, hookTransformResult.Error, "Ref (refs/not/head) is not a head ref")
+		require.Nil(t, hookTransformResult.TriggerAPIParams)
+	}
 }
 
 func Test_HookProvider_TransformRequest(t *testing.T) {
-    provider := HookProvider{}
+	provider := HookProvider{}
 
-    const sampleCodePushData = `{
+	const sampleCodePushData = `{
   "secret": "",
   "ref": "refs/heads/develop",
   "after": "1606d3dd4c4dc83ee8fed8d3cfd911da851bf740",
@@ -167,53 +167,53 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
   ]
 }`
 
-    t.Log("Code Push - should be handled")
-    {
-        request := http.Request{
-            Header: http.Header{
-                "X-Gogs-Event":   {"push"},
-                "Content-Type":   {"application/json"},
-            },
-            Body: ioutil.NopCloser(strings.NewReader(sampleCodePushData)),
-        }
-        hookTransformResult := provider.TransformRequest(&request)
-        require.NoError(t, hookTransformResult.Error)
-        require.False(t, hookTransformResult.ShouldSkip)
-        require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
-            {
-                BuildParams: bitriseapi.BuildParamsModel{
-                    CommitHash:    "1606d3dd4c4dc83ee8fed8d3cfd911da851bf740",
-                    CommitMessage: "second commit message",
-                    Branch:        "develop",
-                },
-            },
-        }, hookTransformResult.TriggerAPIParams)
-    }
+	t.Log("Code Push - should be handled")
+	{
+		request := http.Request{
+			Header: http.Header{
+				"X-Gogs-Event": {"push"},
+				"Content-Type": {"application/json"},
+			},
+			Body: ioutil.NopCloser(strings.NewReader(sampleCodePushData)),
+		}
+		hookTransformResult := provider.TransformRequest(&request)
+		require.NoError(t, hookTransformResult.Error)
+		require.False(t, hookTransformResult.ShouldSkip)
+		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
+			{
+				BuildParams: bitriseapi.BuildParamsModel{
+					CommitHash:    "1606d3dd4c4dc83ee8fed8d3cfd911da851bf740",
+					CommitMessage: "second commit message",
+					Branch:        "develop",
+				},
+			},
+		}, hookTransformResult.TriggerAPIParams)
+	}
 
-    t.Log("Unsuported Content-Type")
-    {
-        request := http.Request{
-            Header: http.Header{
-                "X-Gogs-Event":   {"push"},
-                "Content-Type":   {"not/supported"},
-            },
-            Body: ioutil.NopCloser(strings.NewReader(sampleCodePushData)),
-        }
-        hookTransformResult := provider.TransformRequest(&request)
-        require.False(t, hookTransformResult.ShouldSkip)
-        require.EqualError(t, hookTransformResult.Error, "Content-Type is not supported: not/supported")
-    }
+	t.Log("Unsuported Content-Type")
+	{
+		request := http.Request{
+			Header: http.Header{
+				"X-Gogs-Event": {"push"},
+				"Content-Type": {"not/supported"},
+			},
+			Body: ioutil.NopCloser(strings.NewReader(sampleCodePushData)),
+		}
+		hookTransformResult := provider.TransformRequest(&request)
+		require.False(t, hookTransformResult.ShouldSkip)
+		require.EqualError(t, hookTransformResult.Error, "Content-Type is not supported: not/supported")
+	}
 
-    t.Log("No Request Body")
-    {
-        request := http.Request{
-            Header: http.Header{
-                "X-Gogs-Event":   {"push"},
-                "Content-Type":   {"application/json"},
-            },
-        }
-        hookTransformResult := provider.TransformRequest(&request)
-        require.False(t, hookTransformResult.ShouldSkip)
-        require.EqualError(t, hookTransformResult.Error, "Failed to read content of request body: no or empty request body")
-    }
+	t.Log("No Request Body")
+	{
+		request := http.Request{
+			Header: http.Header{
+				"X-Gogs-Event": {"push"},
+				"Content-Type": {"application/json"},
+			},
+		}
+		hookTransformResult := provider.TransformRequest(&request)
+		require.False(t, hookTransformResult.ShouldSkip)
+		require.EqualError(t, hookTransformResult.Error, "Failed to read content of request body: no or empty request body")
+	}
 }

--- a/service/hook/slack/slack.go
+++ b/service/hook/slack/slack.go
@@ -50,8 +50,13 @@ func getInputTextFromFormRequest(r *http.Request) (string, error) {
 	return text, nil
 }
 
-func collectParamsFromPipeSeparatedText(text string) map[string]string {
+func collectParamsFromPipeSeparatedText(text string) (map[string]string, []bitriseapi.EnvironmentItem) {
+	parseFunc := func(c rune) bool {
+		return c == '[' || c == ']'
+	}
+
 	collectedParams := map[string]string{}
+	environmentParams := []bitriseapi.EnvironmentItem{}
 
 	splits := strings.Split(text, "|")
 	for _, aItm := range splits {
@@ -67,10 +72,21 @@ func collectParamsFromPipeSeparatedText(text string) map[string]string {
 		}
 		key := strings.TrimSpace(itmSplits[0])
 		value := strings.TrimSpace(strings.Join(itmSplits[1:], ":"))
-		collectedParams[key] = value
+		subKeys := strings.FieldsFunc(key, parseFunc)
+
+		if len(subKeys) == 2 {
+			subKeyParent := strings.ToLower(strings.TrimSpace(subKeys[0]))
+			subKey := strings.TrimSpace(subKeys[1])
+			if subKeyParent == "env" {
+				environmentParams = append(environmentParams, bitriseapi.EnvironmentItem{Name: subKey, Value: value, IsExpand: false})
+			}
+		} else if len(subKeys) == 1 {
+			collectedParams[key] = value
+		}
+
 	}
 
-	return collectedParams
+	return collectedParams, environmentParams
 }
 
 func chooseFirstNonEmptyString(strs ...string) string {
@@ -85,7 +101,7 @@ func chooseFirstNonEmptyString(strs ...string) string {
 func transformOutgoingWebhookMessage(slackText string) hookCommon.TransformResultModel {
 	cleanedUpText := strings.TrimSpace(slackText)
 
-	collectedParams := collectParamsFromPipeSeparatedText(cleanedUpText)
+	collectedParams, environments := collectParamsFromPipeSeparatedText(cleanedUpText)
 	//
 	branch := chooseFirstNonEmptyString(collectedParams["branch"], collectedParams["b"])
 	workflowID := chooseFirstNonEmptyString(collectedParams["workflow"], collectedParams["w"])
@@ -109,6 +125,7 @@ func transformOutgoingWebhookMessage(slackText string) hookCommon.TransformResul
 					CommitHash:    commitHash,
 					Tag:           tag,
 					WorkflowID:    workflowID,
+					Environments:  environments,
 				},
 			},
 		},


### PR DESCRIPTION
Hi! I needed this feature: https://bitrise.uservoice.com/forums/235233-general/suggestions/14200494-allow-for-custom-params-for-slack-command-to-be-se

On the chatrooms you guys gave me the option to use the API directly with the advanced build feature, thanks! I take a stab at how I would see this working, sorry I'm awful at Golang! Never had used it before and couldn't make the server run locally to test it working. Please if anyone can review this and make it better...

The usage would be:
Slack command calls `/bitrise branch:develop|env[DEVICE_NAME]:iPhone de Rafael|env[DEVICE_UDID]:8237842783478237878234`

webhook-processor outputs
`"build_params":{"branch":"develop","environments":[{"mapped_to":"DEVICE_NAME","value":"iPhone de Rafael","is_expand":true},{"mapped_to":"DEVICE_UDID","value":"8237842783478237878234","is_expand":true}]}`