### PR TITLE
Experimental skip-ci support for github

### DIFF
--- a/bitriseapi/bitriseapi.go
+++ b/bitriseapi/bitriseapi.go
@@ -41,6 +41,7 @@ type TriggerAPIResponseModel struct {
 
 // SkipAPIResponseModel ...
 type SkipAPIResponseModel struct {
+	Message       string `json:"message"`
 	CommitHash    string `json:"commit_hash"`
 	CommitMessage string `json:"commit_message"`
 	Branch        string `json:"branch"`

--- a/bitriseapi/bitriseapi.go
+++ b/bitriseapi/bitriseapi.go
@@ -39,6 +39,13 @@ type TriggerAPIResponseModel struct {
 	TriggeredWorkflow string `json:"triggered_workflow"`
 }
 
+// SkipAPIResponseModel ...
+type SkipAPIResponseModel struct {
+	CommitHash    string `json:"commit_hash"`
+	CommitMessage string `json:"commit_message"`
+	Branch        string `json:"branch"`
+}
+
 // Validate ...
 func (triggerParams TriggerAPIParamsModel) Validate() error {
 	if triggerParams.BuildParams.Branch == "" && triggerParams.BuildParams.WorkflowID == "" {

--- a/service/hook/common/common.go
+++ b/service/hook/common/common.go
@@ -43,6 +43,8 @@ type TransformResponseModel struct {
 type TransformResponseInputModel struct {
 	// Errors include the errors if the build could not trigger
 	Errors []string
+	SkipResponses        []bitriseapi.SkipAPIResponseModel
+
 	// SuccessTriggerResponses include the successful trigger call responses
 	SuccessTriggerResponses []bitriseapi.TriggerAPIResponseModel
 	// FailedTriggerResponses include the trigger calls which were performed,

--- a/service/hook/common/common.go
+++ b/service/hook/common/common.go
@@ -43,13 +43,15 @@ type TransformResponseModel struct {
 type TransformResponseInputModel struct {
 	// Errors include the errors if the build could not trigger
 	Errors                  []string
-	SkippedTriggerResponses []bitriseapi.SkipAPIResponseModel
 
 	// SuccessTriggerResponses include the successful trigger call responses
 	SuccessTriggerResponses []bitriseapi.TriggerAPIResponseModel
 	// FailedTriggerResponses include the trigger calls which were performed,
 	//  but the response had a non success HTTP status code
 	FailedTriggerResponses []bitriseapi.TriggerAPIResponseModel
+	// SkippedTriggerResponses include responses for the trigger calls
+	//  that were skipped
+	SkippedTriggerResponses []bitriseapi.SkipAPIResponseModel
 }
 
 // ResponseTransformer ...

--- a/service/hook/common/common.go
+++ b/service/hook/common/common.go
@@ -42,8 +42,8 @@ type TransformResponseModel struct {
 // TransformResponseInputModel ...
 type TransformResponseInputModel struct {
 	// Errors include the errors if the build could not trigger
-	Errors []string
-	SkipResponses        []bitriseapi.SkipAPIResponseModel
+	Errors                  []string
+	SkippedTriggerResponses []bitriseapi.SkipAPIResponseModel
 
 	// SuccessTriggerResponses include the successful trigger call responses
 	SuccessTriggerResponses []bitriseapi.TriggerAPIResponseModel

--- a/service/hook/default_response_provider.go
+++ b/service/hook/default_response_provider.go
@@ -27,6 +27,7 @@ type SuccessRespModel struct {
 // TransformResponseModel ...
 type TransformResponseModel struct {
 	Errors                  []string                             `json:"errors,omitempty"`
+	SkipResponses           []bitriseapi.SkipAPIResponseModel    `json:"skipped,omitempty"`
 	SuccessTriggerResponses []bitriseapi.TriggerAPIResponseModel `json:"success_responses"`
 	FailedTriggerResponses  []bitriseapi.TriggerAPIResponseModel `json:"failed_responses,omitempty"`
 }
@@ -34,6 +35,11 @@ type TransformResponseModel struct {
 // TransformResponse ...
 func (hp DefaultResponseProvider) TransformResponse(input hookCommon.TransformResponseInputModel) hookCommon.TransformResponseModel {
 	httpStatusCode := 201
+
+	if len(input.SuccessTriggerResponses) == 0 && len(input.SkipResponses) > 0 {
+		httpStatusCode = 200
+	}
+
 	if len(input.Errors) > 0 || len(input.FailedTriggerResponses) > 0 {
 		httpStatusCode = 400
 	}
@@ -43,6 +49,7 @@ func (hp DefaultResponseProvider) TransformResponse(input hookCommon.TransformRe
 			Errors:                  input.Errors,
 			SuccessTriggerResponses: input.SuccessTriggerResponses,
 			FailedTriggerResponses:  input.FailedTriggerResponses,
+			SkipResponses:  input.SkipResponses,
 		},
 		HTTPStatusCode: httpStatusCode,
 	}

--- a/service/hook/default_response_provider.go
+++ b/service/hook/default_response_provider.go
@@ -27,9 +27,9 @@ type SuccessRespModel struct {
 // TransformResponseModel ...
 type TransformResponseModel struct {
 	Errors                  []string                             `json:"errors,omitempty"`
-	SkippedTriggerResponses []bitriseapi.SkipAPIResponseModel    `json:"skipped,omitempty"`
 	SuccessTriggerResponses []bitriseapi.TriggerAPIResponseModel `json:"success_responses"`
 	FailedTriggerResponses  []bitriseapi.TriggerAPIResponseModel `json:"failed_responses,omitempty"`
+	SkippedTriggerResponses []bitriseapi.SkipAPIResponseModel    `json:"skipped_responses,omitempty"`
 }
 
 // TransformResponse ...

--- a/service/hook/default_response_provider.go
+++ b/service/hook/default_response_provider.go
@@ -27,7 +27,7 @@ type SuccessRespModel struct {
 // TransformResponseModel ...
 type TransformResponseModel struct {
 	Errors                  []string                             `json:"errors,omitempty"`
-	SkipResponses           []bitriseapi.SkipAPIResponseModel    `json:"skipped,omitempty"`
+	SkippedTriggerResponses []bitriseapi.SkipAPIResponseModel    `json:"skipped,omitempty"`
 	SuccessTriggerResponses []bitriseapi.TriggerAPIResponseModel `json:"success_responses"`
 	FailedTriggerResponses  []bitriseapi.TriggerAPIResponseModel `json:"failed_responses,omitempty"`
 }
@@ -36,7 +36,7 @@ type TransformResponseModel struct {
 func (hp DefaultResponseProvider) TransformResponse(input hookCommon.TransformResponseInputModel) hookCommon.TransformResponseModel {
 	httpStatusCode := 201
 
-	if len(input.SuccessTriggerResponses) == 0 && len(input.SkipResponses) > 0 {
+	if len(input.SuccessTriggerResponses) == 0 && len(input.SkippedTriggerResponses) > 0 {
 		httpStatusCode = 200
 	}
 
@@ -49,7 +49,7 @@ func (hp DefaultResponseProvider) TransformResponse(input hookCommon.TransformRe
 			Errors:                  input.Errors,
 			SuccessTriggerResponses: input.SuccessTriggerResponses,
 			FailedTriggerResponses:  input.FailedTriggerResponses,
-			SkipResponses:  input.SkipResponses,
+			SkippedTriggerResponses: input.SkippedTriggerResponses,
 		},
 		HTTPStatusCode: httpStatusCode,
 	}

--- a/service/hook/endpoint.go
+++ b/service/hook/endpoint.go
@@ -172,18 +172,19 @@ func HTTPHandler(w http.ResponseWriter, r *http.Request) {
 	respondWith := hookCommon.TransformResponseInputModel{
 		Errors:                  []string{},
 		SuccessTriggerResponses: []bitriseapi.TriggerAPIResponseModel{},
-		SkipResponses:           []bitriseapi.SkipAPIResponseModel{},
+		SkippedTriggerResponses: []bitriseapi.SkipAPIResponseModel{},
 		FailedTriggerResponses:  []bitriseapi.TriggerAPIResponseModel{},
 	}
 	metrics.Trace("Hook: Trigger Builds", func() {
 		for _, aBuildTriggerParam := range hookTransformResult.TriggerAPIParams {
 			commitMessage := aBuildTriggerParam.BuildParams.CommitMessage
 
-			if (strings.Contains(commitMessage, "[skip ci]") || strings.Contains(commitMessage, "[ci skip]")) {
-				respondWith.SkipResponses = append(respondWith.SkipResponses, bitriseapi.SkipAPIResponseModel{
-					CommitHash:  aBuildTriggerParam.BuildParams.CommitHash,
+			if strings.Contains(commitMessage, "[skip ci]") || strings.Contains(commitMessage, "[ci skip]") {
+				respondWith.SkippedTriggerResponses = append(respondWith.SkippedTriggerResponses, bitriseapi.SkipAPIResponseModel{
+					Message:       "Build skipped by request",
+					CommitHash:    aBuildTriggerParam.BuildParams.CommitHash,
 					CommitMessage: aBuildTriggerParam.BuildParams.CommitMessage,
-					Branch: aBuildTriggerParam.BuildParams.Branch,
+					Branch:        aBuildTriggerParam.BuildParams.Branch,
 				})
 				continue
 			}

--- a/service/hook/endpoint.go
+++ b/service/hook/endpoint.go
@@ -181,7 +181,7 @@ func HTTPHandler(w http.ResponseWriter, r *http.Request) {
 
 			if strings.Contains(commitMessage, "[skip ci]") || strings.Contains(commitMessage, "[ci skip]") {
 				respondWith.SkippedTriggerResponses = append(respondWith.SkippedTriggerResponses, bitriseapi.SkipAPIResponseModel{
-					Message:       "Build skipped by request",
+					Message:       "Build skipped because the commit message included a skip ci keyword ([skip ci] or [ci skip]).",
 					CommitHash:    aBuildTriggerParam.BuildParams.CommitHash,
 					CommitMessage: aBuildTriggerParam.BuildParams.CommitMessage,
 					Branch:        aBuildTriggerParam.BuildParams.Branch,

--- a/service/hook/endpoint.go
+++ b/service/hook/endpoint.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/bitrise-io/bitrise-webhooks/bitriseapi"
 	"github.com/bitrise-io/bitrise-webhooks/config"
@@ -171,10 +172,22 @@ func HTTPHandler(w http.ResponseWriter, r *http.Request) {
 	respondWith := hookCommon.TransformResponseInputModel{
 		Errors:                  []string{},
 		SuccessTriggerResponses: []bitriseapi.TriggerAPIResponseModel{},
+		SkipResponses:           []bitriseapi.SkipAPIResponseModel{},
 		FailedTriggerResponses:  []bitriseapi.TriggerAPIResponseModel{},
 	}
 	metrics.Trace("Hook: Trigger Builds", func() {
 		for _, aBuildTriggerParam := range hookTransformResult.TriggerAPIParams {
+			commitMessage := aBuildTriggerParam.BuildParams.CommitMessage
+
+			if (strings.Contains(commitMessage, "[skip ci]") || strings.Contains(commitMessage, "[ci skip]")) {
+				respondWith.SkipResponses = append(respondWith.SkipResponses, bitriseapi.SkipAPIResponseModel{
+					CommitHash:  aBuildTriggerParam.BuildParams.CommitHash,
+					CommitMessage: aBuildTriggerParam.BuildParams.CommitMessage,
+					Branch: aBuildTriggerParam.BuildParams.Branch,
+				})
+				continue
+			}
+
 			if triggerResp, isSuccess, err := triggerBuild(triggerURL, apiToken, aBuildTriggerParam); err != nil {
 				respondWith.Errors = append(respondWith.Errors, fmt.Sprintf("Failed to Trigger Build: %s", err))
 			} else if isSuccess {


### PR DESCRIPTION
My first lines of Go code so apologies if it is totally out of place :)

I was trying to implement this in the common code as suggested here: https://github.com/bitrise-io/bitrise-webhooks/issues/2 but couldn't realize how to access the commit message from there so decided to put in the TransformRequest instead which seemed like good place because it already has ShouldSkip.

Would like to hear if this is good way to do it or if it should be placed somewhere else? 
Also this only implements it for the github push event so would need to implement it other places also where needed...

