### PR TITLE
Update menu item name for GitHub instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ a [GitHub](https://github.com) *repository*.
 
 1. Open your *repository* on [GitHub.com](https://github.com)
 2. Go to `Settings` of the *repository*
-3. Select `Webhooks & services`
+3. Select `Webhooks`
 4. Click on `Add webhook`
 5. Specify the `bitrise-webhooks` URL (`.../h/github/BITRISE-APP-SLUG/BITRISE-APP-API-TOKEN`) in the `Payload URL` field
 6. Select the *events* you want to trigger a webhook for


### PR DESCRIPTION
Looks like Github has renamed it.

![2016-11-04_1735](https://cloud.githubusercontent.com/assets/217368/20026289/b9aa92d2-a2b5-11e6-8754-009acb351ea7.png)
