### PR TITLE
Add support for Tag triggers in GOGS/Gitea Webhook service

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If the (commit) message includes `[skip ci]` or `[ci skip]` no build will be tri
   * handled on the path: `/h/visualstudio/BITRISE-APP-SLUG/BITRISE-APP-API-TOKEN`
 * [GitLab](https://gitlab.com)
   * handled on the path: `/h/gitlab/BITRISE-APP-SLUG/BITRISE-APP-API-TOKEN`
-* [Gogs](https://gogs.io)
+* [Gogs](https://gogs.io) or [Gitea](https://gitea.io)
   * handled on the path: `/h/gogs/BITRISE-APP-SLUG/BITRISE-APP-API-TOKEN`
 * [Deveo](https://deveo.com)
   * handled on the path: `/h/deveo/BITRISE-APP-SLUG/BITRISE-APP-API-TOKEN`
@@ -92,7 +92,8 @@ a build will be triggered (if you have Trigger mapping defined for the event(s) 
 
 ### Gogs - setup & usage:
 
-All you have to do is register your `bitrise-webhooks` URL as a Webhook in your [Gogs](https://gogs.io) repository.
+All you have to do is register your `bitrise-webhooks` URL as a Webhook in your [Gogs](https://gogs.io)
+or [Gitea](https://gitea.io) repository. (Both repositories use the same Webhook format.)
 
 1. Open your *project* on your repository's hosting URL.
 1. Go to `Settings` of the *project*
@@ -100,7 +101,8 @@ All you have to do is register your `bitrise-webhooks` URL as a Webhook in your 
 1. Specify the `bitrise-webhooks` URL (`.../h/gogs/BITRISE-APP-SLUG/BITRISE-APP-API-TOKEN`) in the `Payload URL` field.
 1. Set the `Content Type` to `application/json`.
 1. A Secret is not required at this time.
-1. Set the trigger to be fired on `Just the push event`
+1. Set the trigger to be fired on either `Just the push event` or `Let me choose what I need` and select
+`Create` and `Push`. (Pull request triggers are not supported at this time.)
 1. Save the Webhook.
 
 That's all! The next time you __push code__

--- a/service/hook/gogs/gogs.go
+++ b/service/hook/gogs/gogs.go
@@ -42,6 +42,7 @@ type PushEventModel struct {
 	Commits     []CommitModel `json:"commits"`
 }
 
+// TagEventModel ...
 type TagEventModel struct {
 	Secret  string `json:"secret"`
 	Ref     string `json:"ref"`

--- a/service/hook/gogs/gogs_test.go
+++ b/service/hook/gogs/gogs_test.go
@@ -49,7 +49,7 @@ func Test_detectContentTypeAndEventID(t *testing.T) {
 func Test_transformCodePushEvent(t *testing.T) {
 	t.Log("Do Transform - single commit")
 	{
-		codePush := CodePushEventModel{
+		codePush := PushEventModel{
 			Secret:      "",
 			Ref:         "refs/heads/master",
 			CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
@@ -60,7 +60,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 				},
 			},
 		}
-		hookTransformResult := transformCodePushEvent(codePush)
+		hookTransformResult := transformPushEvent(codePush)
 		require.NoError(t, hookTransformResult.Error)
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
@@ -76,7 +76,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 
 	t.Log("Do Transform - multiple commits - CheckoutSHA match should trigger the build")
 	{
-		codePush := CodePushEventModel{
+		codePush := PushEventModel{
 			Secret:      "",
 			Ref:         "refs/heads/master",
 			CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
@@ -95,7 +95,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 				},
 			},
 		}
-		hookTransformResult := transformCodePushEvent(codePush)
+		hookTransformResult := transformPushEvent(codePush)
 		require.NoError(t, hookTransformResult.Error)
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
@@ -111,7 +111,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 
 	t.Log("No commit matches CheckoutSHA")
 	{
-		codePush := CodePushEventModel{
+		codePush := PushEventModel{
 			Secret:      "",
 			Ref:         "refs/heads/master",
 			CheckoutSHA: "checkout-sha",
@@ -122,28 +122,9 @@ func Test_transformCodePushEvent(t *testing.T) {
 				},
 			},
 		}
-		hookTransformResult := transformCodePushEvent(codePush)
+		hookTransformResult := transformPushEvent(codePush)
 		require.EqualError(t, hookTransformResult.Error, "The commit specified by 'after' was not included in the 'commits' array - no match found")
-		require.False(t, hookTransformResult.ShouldSkip)
-		require.Nil(t, hookTransformResult.TriggerAPIParams)
-	}
-
-	t.Log("Not a head ref")
-	{
-		codePush := CodePushEventModel{
-			Secret:      "",
-			Ref:         "refs/not/head",
-			CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
-			Commits: []CommitModel{
-				{
-					CommitHash:    "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
-					CommitMessage: `Response: omit the "failed_responses" array if empty`,
-				},
-			},
-		}
-		hookTransformResult := transformCodePushEvent(codePush)
 		require.True(t, hookTransformResult.ShouldSkip)
-		require.EqualError(t, hookTransformResult.Error, "Ref (refs/not/head) is not a head ref")
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
 	}
 }
@@ -165,6 +146,12 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
       "message": "second commit message"
     }
   ]
+}`
+
+	const sampleTagPushData = `{
+  "secret": "",
+  "ref": "v1.12",
+  "ref_type": "tag"
 }`
 
 	t.Log("Code Push - should be handled")
@@ -190,7 +177,28 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		}, hookTransformResult.TriggerAPIParams)
 	}
 
-	t.Log("Unsuported Content-Type")
+	t.Log("Tag Push - should be handled")
+	{
+		request := http.Request{
+			Header: http.Header{
+				"X-Gogs-Event": {"create"},
+				"Content-Type": {"application/json"},
+			},
+			Body: ioutil.NopCloser(strings.NewReader(sampleTagPushData)),
+		}
+		hookTransformResult := provider.TransformRequest(&request)
+		require.NoError(t, hookTransformResult.Error)
+		require.False(t, hookTransformResult.ShouldSkip)
+		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
+			{
+				BuildParams: bitriseapi.BuildParamsModel{
+					Tag: "v1.12",
+				},
+			},
+		}, hookTransformResult.TriggerAPIParams)
+	}
+
+	t.Log("Unsupported Content-Type")
 	{
 		request := http.Request{
 			Header: http.Header{


### PR DESCRIPTION
This PR addresses https://github.com/bitrise-io/bitrise-webhooks/issues/30 with two changes:

1. Adds support for Tag triggers, which are sent as `ref_type: "tag", ref: "TAGNAME"`.
1. Adds doc references to Gitea, which the GOGS handler is compatible with (since Gitea is a GOGS fork).
