### PR TITLE
Bitbucket mercurial support

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,7 +15,7 @@
     },
     "SEND_REQUEST_TO": {
       "description": "DEBUG: set a specific URL, where every request will be sent by the server, instead of sending the trigger requests to bitrise.io",
-      "value": "https://www.bitrise.io/app/124669265167ed74/build/start.json",
+      "value": "",
       "required": false
     }
   }

--- a/app.json
+++ b/app.json
@@ -15,7 +15,7 @@
     },
     "SEND_REQUEST_TO": {
       "description": "DEBUG: set a specific URL, where every request will be sent by the server, instead of sending the trigger requests to bitrise.io",
-      "value": "",
+      "value": "https://www.bitrise.io/app/124669265167ed74/build/start.json",
       "required": false
     }
   }

--- a/service/hook/bitbucketv2/bitbucketv2.go
+++ b/service/hook/bitbucketv2/bitbucketv2.go
@@ -126,7 +126,7 @@ func transformPushEvent(pushEvent PushEventModel) hookCommon.TransformResultMode
 	errs := []string{}
 	for _, aChnage := range pushEvent.PushInfo.Changes {
 		aNewItm := aChnage.ChangeNewItem
-		if aNewItm.Type == "branch" {
+		if aNewItm.Type == "branch" || aNewItm.Type == "named_branch" {
 			if aNewItm.Target.Type != "commit" {
 				errs = append(errs, fmt.Sprintf("Target was not a type=commit change. Type was: %s", aNewItm.Target.Type))
 				continue

--- a/service/hook/bitbucketv2/bitbucketv2_test.go
+++ b/service/hook/bitbucketv2/bitbucketv2_test.go
@@ -41,6 +41,24 @@ const (
 }
 }`
 
+	sampleMercurialCodePushData = `{
+"push": {
+	"changes": [
+		{
+			"new": {
+				"name": "master",
+				"type": "named_branch",
+				"target": {
+					"type": "commit",
+					"message": "auto-test",
+					"hash": "966d0bfe79b80f97268c2f6bb45e65e79ef09b31"
+				}
+			}
+		}
+	]
+}
+}`
+
 	sampleTagPushData = `{
 "push": {
 	"changes": [
@@ -769,6 +787,36 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		}, hookTransformResult.TriggerAPIParams)
 	}
 
+	t.Log("Test with Sample Mercurial Code Push data")
+	{
+		request := http.Request{
+			Header: http.Header{
+				"X-Event-Key":      {"repo:push"},
+				"Content-Type":     {"application/json"},
+				"X-Attempt-Number": {"1"},
+			},
+			Body: ioutil.NopCloser(strings.NewReader(sampleMercurialCodePushData)),
+		}
+		hookTransformResult := provider.TransformRequest(&request)
+		require.NoError(t, hookTransformResult.Error)
+		require.False(t, hookTransformResult.ShouldSkip)
+		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
+			{
+				BuildParams: bitriseapi.BuildParamsModel{
+					CommitHash:    "966d0bfe79b80f97268c2f6bb45e65e79ef09b31",
+					CommitMessage: "auto-test",
+					Branch:        "master",
+				},
+			},
+			{
+				BuildParams: bitriseapi.BuildParamsModel{
+					CommitHash:    "19934139a2cf799bbd0f5061ab02e4760902e93f",
+					CommitMessage: "auto-test 2",
+					Branch:        "test",
+				},
+			},
+		}, hookTransformResult.TriggerAPIParams)
+	}
 	t.Log("Test with Sample Tag Push data")
 	{
 		request := http.Request{

--- a/service/hook/bitbucketv2/bitbucketv2_test.go
+++ b/service/hook/bitbucketv2/bitbucketv2_test.go
@@ -808,13 +808,6 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 					Branch:        "master",
 				},
 			},
-			{
-				BuildParams: bitriseapi.BuildParamsModel{
-					CommitHash:    "19934139a2cf799bbd0f5061ab02e4760902e93f",
-					CommitMessage: "auto-test 2",
-					Branch:        "test",
-				},
-			},
 		}, hookTransformResult.TriggerAPIParams)
 	}
 	t.Log("Test with Sample Tag Push data")

--- a/service/hook/bitbucketv2/bitbucketv2_test.go
+++ b/service/hook/bitbucketv2/bitbucketv2_test.go
@@ -54,6 +54,17 @@ const (
 					"hash": "966d0bfe79b80f97268c2f6bb45e65e79ef09b31"
 				}
 			}
+		},
+		{
+			"new": {
+				"name": "test",
+				"type": "named_branch",
+				"target": {
+					"type": "commit",
+					"message": "auto-test 2",
+					"hash": "19934139a2cf799bbd0f5061ab02e4760902e93f"
+				}
+			}
 		}
 	]
 }
@@ -806,6 +817,13 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 					CommitHash:    "966d0bfe79b80f97268c2f6bb45e65e79ef09b31",
 					CommitMessage: "auto-test",
 					Branch:        "master",
+				},
+			},
+			{
+				BuildParams: bitriseapi.BuildParamsModel{
+					CommitHash:    "19934139a2cf799bbd0f5061ab02e4760902e93f",
+					CommitMessage: "auto-test 2",
+					Branch:        "test",
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)


### PR DESCRIPTION
As documented in [here](https://confluence.atlassian.com/bitbucket/event-payloads-740262817.html) mercurial repositories have `named_branch` instead of `branch` typeoin bitrise webhooks.

- type: The type of reference with the change. 
  - branch, or tag for Git repositories.
  - named_branch, bookmark or tag for Mercurial repositories.

This PR enable wehbhooks to work with mercurial repositories.
