### PR TITLE
DontWaitForTriggerResponse option added - return a response for GitLab as fast as possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For more information check the *How to add support for a new Provider* section.
 
 
 ## CI Skip
- 
+
 If the (commit) message includes `[skip ci]` or `[ci skip]` no build will be triggered.
 
 
@@ -148,7 +148,7 @@ a [Deveo](https://deveo.com) *repository*.
 6. Type `json` in the `Content type` field
 6. Click `Save hook`
 
-That's all! The next time you __push code__ or __push a new tag__ 
+That's all! The next time you __push code__ or __push a new tag__
 a build will be triggered (if you have Trigger mapping defined for the event(s) on Bitrise).
 
 ### Slack - setup & usage:
@@ -370,13 +370,22 @@ response provider will be used.
   declared as a success, instead of an error) then a `{"message": "..."}` response
   will be generated (with HTTP status code `200`).
 * If at least one Bitrise Trigger call was initiated:
-  * All the received responses will be included as a `"success_responses": []`
-    and `"failed_responses": []` JSON arrays
-  * And all the errors (where the response was not available / call timed out, etc.)
-    as a `"errors": []` JSON array (if any)
-  * If at least one call fails or the response is an error response
-    the HTTP status code will be `400`
-  * If all trigger calls succeed the status code will be `201`
+    * All the received responses will be included as a `"success_responses": []`
+      and `"failed_responses": []` JSON arrays
+    * And all the errors (where the response was not available / call timed out, etc.)
+      as a `"errors": []` JSON array (if any)
+    * If at least one call fails or the response is an error response
+      the HTTP status code will be `400`
+    * If all trigger calls succeed the status code will be `201`
+* If the provider declares that it does not want to wait for the Trigger API response,
+  then a response will be returned immediately after triggering a build (calling the Trigger API),
+  and in the response there will be no information about the Trigger API call's response.
+  In this case the response is `{"did_not_wait_for_trigger_response": true}` with
+  a HTTP `200` code.
+    * An example is the GitLab hook processor/provider, where GitLab does not store the returned
+      response, there's no history for webhook calls, and it does retry the webhook call
+      if the response is too slow. So in case of GitLab we don't wait for the response of the Trigger API,
+      we just return the did not wait response.
 
 
 ## TODO

--- a/service/hook/bitbucketv2/bitbucketv2_test.go
+++ b/service/hook/bitbucketv2/bitbucketv2_test.go
@@ -290,6 +290,7 @@ func Test_transformPushEvent(t *testing.T) {
 					},
 				},
 			}, hookTransformResult.TriggerAPIParams)
+			require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 		}
 
 		// no Scm info
@@ -299,6 +300,7 @@ func Test_transformPushEvent(t *testing.T) {
 			require.EqualError(t, hookTransformResult.Error, "Unsupported repository / source control type (SCM): invalid-scm-or-empty")
 			require.False(t, hookTransformResult.ShouldSkip)
 			require.Nil(t, hookTransformResult.TriggerAPIParams)
+			require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 		}
 	}
 
@@ -336,6 +338,7 @@ func Test_transformPushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Do Transform - multiple changes - code push")
@@ -390,6 +393,7 @@ func Test_transformPushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Do Transform - multiple changes - tag push")
@@ -444,6 +448,7 @@ func Test_transformPushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Multiple changes, one of the changes is a not supported (type) change")
@@ -491,6 +496,7 @@ func Test_transformPushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("One of the changes.Target is not a type=commit change")
@@ -538,6 +544,7 @@ func Test_transformPushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Not a Branch nor Tag push event")
@@ -561,6 +568,7 @@ func Test_transformPushEvent(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "'changes' specified in the webhook, but none can be transformed into a build. Collected errors: [Not a type=branch nor type=tag change. Change.Type was: not-branch-nor-tag]")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Not a 'Commit' type change")
@@ -587,6 +595,7 @@ func Test_transformPushEvent(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "'changes' specified in the webhook, but none can be transformed into a build. Collected errors: [Target was not a type=commit change. Type was: unsupported-type]")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 }
 
@@ -687,6 +696,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Pull Request - Title & Body")
@@ -738,6 +748,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 }
 
@@ -781,6 +792,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "No retry is supported (X-Attempt-Number: 2)")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Unsupported Event Type")
@@ -854,6 +866,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Test with Sample Mercurial Code Push data")
@@ -885,6 +898,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 	t.Log("Test with Sample Tag Push data")
 	{
@@ -915,6 +929,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Test with Sample Pull Request data")
@@ -942,6 +957,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("X-Attempt-Number=1 - OK")
@@ -973,6 +989,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("X-Attempt-Number=2 - SKIP")
@@ -989,5 +1006,6 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "No retry is supported (X-Attempt-Number: 2)")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 }

--- a/service/hook/common/common.go
+++ b/service/hook/common/common.go
@@ -23,6 +23,10 @@ type TransformResultModel struct {
 	// Error in transforming the hook. If ShouldSkip=true this is
 	//  the reason why the hook should be skipped.
 	Error error
+	// DontWaitForTriggerResponse if true the Trigger API request will be sent,
+	//  but the handler won't wait for the response from the Trigger API,
+	//  it'll respond immediately after calling the Trigger API
+	DontWaitForTriggerResponse bool
 }
 
 // Provider ...
@@ -58,6 +62,10 @@ type SkipAPIResponseModel struct {
 type TransformResponseInputModel struct {
 	// Errors include the errors if the build could not trigger
 	Errors []string
+
+	// DidNotWaitForTriggerResponse if true it means that the TriggerResponses were not populated,
+	//  as the provider requested to skip waiting for the Trigger API call's response/result.
+	DidNotWaitForTriggerResponse bool
 
 	// SuccessTriggerResponses include the successful trigger call responses
 	SuccessTriggerResponses []bitriseapi.TriggerAPIResponseModel

--- a/service/hook/common/default_response_provider.go
+++ b/service/hook/common/default_response_provider.go
@@ -20,15 +20,20 @@ type SuccessRespModel struct {
 
 // DefaultTransformResponseModel ...
 type DefaultTransformResponseModel struct {
-	Errors                  []string                             `json:"errors,omitempty"`
-	SuccessTriggerResponses []bitriseapi.TriggerAPIResponseModel `json:"success_responses"`
-	FailedTriggerResponses  []bitriseapi.TriggerAPIResponseModel `json:"failed_responses,omitempty"`
-	SkippedTriggerResponses []SkipAPIResponseModel               `json:"skipped_responses,omitempty"`
+	Errors                       []string                             `json:"errors,omitempty"`
+	DidNotWaitForTriggerResponse bool                                 `json:"did_not_wait_for_trigger_response,omitempty"`
+	SuccessTriggerResponses      []bitriseapi.TriggerAPIResponseModel `json:"success_responses"`
+	FailedTriggerResponses       []bitriseapi.TriggerAPIResponseModel `json:"failed_responses,omitempty"`
+	SkippedTriggerResponses      []SkipAPIResponseModel               `json:"skipped_responses,omitempty"`
 }
 
 // TransformResponse ...
 func (hp DefaultResponseProvider) TransformResponse(input TransformResponseInputModel) TransformResponseModel {
 	httpStatusCode := 201
+
+	if input.DidNotWaitForTriggerResponse {
+		httpStatusCode = 200
+	}
 
 	if len(input.SuccessTriggerResponses) == 0 && len(input.SkippedTriggerResponses) > 0 {
 		httpStatusCode = 200
@@ -40,10 +45,11 @@ func (hp DefaultResponseProvider) TransformResponse(input TransformResponseInput
 
 	return TransformResponseModel{
 		Data: DefaultTransformResponseModel{
-			Errors:                  input.Errors,
-			SuccessTriggerResponses: input.SuccessTriggerResponses,
-			FailedTriggerResponses:  input.FailedTriggerResponses,
-			SkippedTriggerResponses: input.SkippedTriggerResponses,
+			Errors: input.Errors,
+			DidNotWaitForTriggerResponse: input.DidNotWaitForTriggerResponse,
+			SuccessTriggerResponses:      input.SuccessTriggerResponses,
+			FailedTriggerResponses:       input.FailedTriggerResponses,
+			SkippedTriggerResponses:      input.SkippedTriggerResponses,
 		},
 		HTTPStatusCode: httpStatusCode,
 	}

--- a/service/hook/deveo/deveo_test.go
+++ b/service/hook/deveo/deveo_test.go
@@ -105,6 +105,7 @@ func Test_transformPushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Do Transform - Tag Push")
@@ -131,6 +132,7 @@ func Test_transformPushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Not Distinct Head Commit - should still trigger a build (e.g. this can happen if you rebase-merge a branch, without creating a merge commit)")
@@ -157,6 +159,7 @@ func Test_transformPushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Tag - Not Distinct Head Commit - should still trigger a build")
@@ -183,6 +186,7 @@ func Test_transformPushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Missing Commit Hash")
@@ -200,6 +204,7 @@ func Test_transformPushEvent(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "Missing commit hash")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Missing Commit Hash - Tag")
@@ -217,6 +222,7 @@ func Test_transformPushEvent(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "Missing commit hash")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("This is a 'deleted' event")
@@ -236,6 +242,7 @@ func Test_transformPushEvent(t *testing.T) {
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.EqualError(t, hookTransformResult.Error, "This is a 'Deleted' event, no build can be started")
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("This is a 'deleted' event - Tag")
@@ -255,6 +262,7 @@ func Test_transformPushEvent(t *testing.T) {
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.EqualError(t, hookTransformResult.Error, "This is a 'Deleted' event, no build can be started")
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Not a head nor a tag ref")
@@ -273,6 +281,7 @@ func Test_transformPushEvent(t *testing.T) {
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.EqualError(t, hookTransformResult.Error, "Ref (refs/not/head) is not a head nor a tag ref")
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 }
 
@@ -352,6 +361,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Tag Push - should be handled")
@@ -375,5 +385,6 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 }

--- a/service/hook/github/github_test.go
+++ b/service/hook/github/github_test.go
@@ -202,6 +202,7 @@ func Test_transformPushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Do Transform - Tag Push")
@@ -226,6 +227,7 @@ func Test_transformPushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Not Distinct Head Commit - should still trigger a build (e.g. this can happen if you rebase-merge a PR, without creating a merge commit)")
@@ -250,6 +252,7 @@ func Test_transformPushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Tag - Not Distinct Head Commit - should still trigger a build")
@@ -274,6 +277,7 @@ func Test_transformPushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Missing Commit Hash")
@@ -289,6 +293,7 @@ func Test_transformPushEvent(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "Missing commit hash")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Missing Commit Hash - Tag")
@@ -304,6 +309,7 @@ func Test_transformPushEvent(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "Missing commit hash")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("This is a 'deleted' event")
@@ -321,6 +327,7 @@ func Test_transformPushEvent(t *testing.T) {
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.EqualError(t, hookTransformResult.Error, "This is a 'Deleted' event, no build can be started")
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("This is a 'deleted' event - Tag")
@@ -338,6 +345,7 @@ func Test_transformPushEvent(t *testing.T) {
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.EqualError(t, hookTransformResult.Error, "This is a 'Deleted' event, no build can be started")
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Not a head nor a tag ref")
@@ -354,6 +362,7 @@ func Test_transformPushEvent(t *testing.T) {
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.EqualError(t, hookTransformResult.Error, "Ref (refs/not/head) is not a head nor a tag ref")
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 }
 
@@ -449,6 +458,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Mergeable: true")
@@ -497,6 +507,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Pull Request - Title & Body")
@@ -546,6 +557,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Pull Request - edited - only title change - no skip ci change - no build")
@@ -587,6 +599,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "Pull Request edit doesn't require a build: only title and/or description was changed, and previous one was not skipped")
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel(nil), hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Pull Request - edited - only title changed - BUT the previous title included a skip CI pattern - should build")
@@ -641,6 +654,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Pull Request - edited - only body/description change - no skip ci in previous - no build")
@@ -682,6 +696,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "Pull Request edit doesn't require a build: only title and/or description was changed, and previous one was not skipped")
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel(nil), hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Pull Request - edited - only body/description change - BUT the previous title included a skip CI pattern - should build")
@@ -736,6 +751,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 }
 
@@ -861,6 +877,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Tag Push - should be handled")
@@ -884,6 +901,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Pull Request - should be handled")
@@ -912,6 +930,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Pull Request :: edited - should be handled")
@@ -940,5 +959,6 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 }

--- a/service/hook/gitlab/gitlab_test.go
+++ b/service/hook/gitlab/gitlab_test.go
@@ -154,6 +154,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Do Transform - multiple commits - CheckoutSHA match should trigger the build")
@@ -189,6 +190,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("No commit matches CheckoutSHA")
@@ -208,6 +210,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "The commit specified by 'checkout_sha' was not included in the 'commits' array - no match found")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Not a head ref")
@@ -227,6 +230,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.EqualError(t, hookTransformResult.Error, "Ref (refs/not/head) is not a head ref")
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 }
 
@@ -249,6 +253,7 @@ func Test_transformTagPushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("No CheckoutSHA (tag delete)")
@@ -262,6 +267,7 @@ func Test_transformTagPushEvent(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "This is a Tag Deleted event, no build is required")
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Not a tags ref")
@@ -275,6 +281,7 @@ func Test_transformTagPushEvent(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "Ref (refs/not/a/tag) is not a tags ref")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Not a tag_push object")
@@ -288,6 +295,7 @@ func Test_transformTagPushEvent(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "Not a Tag Push object: not-a-tag_push")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 }
 
@@ -383,6 +391,7 @@ func Test_transformMergeRequestEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Pull Request - Title & Body")
@@ -428,6 +437,7 @@ func Test_transformMergeRequestEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 }
 
@@ -515,6 +525,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Push: Tag (create)")
@@ -541,6 +552,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Push: Tag Delete")
@@ -560,6 +572,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "This is a Tag Deleted event, no build is required")
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Merge Request - should be handled")
@@ -587,6 +600,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Unsuported Content-Type")

--- a/service/hook/gitlab/gitlab_test.go
+++ b/service/hook/gitlab/gitlab_test.go
@@ -308,6 +308,8 @@ func Test_transformMergeRequestEvent(t *testing.T) {
 		hookTransformResult := transformMergeRequestEvent(mergeRequest)
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.EqualError(t, hookTransformResult.Error, "Not a Merge Request object")
+		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Empty Merge Request state")
@@ -319,6 +321,8 @@ func Test_transformMergeRequestEvent(t *testing.T) {
 		hookTransformResult := transformMergeRequestEvent(mergeRequest)
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.EqualError(t, hookTransformResult.Error, "No Merge Request state specified")
+		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Already Merged")
@@ -333,6 +337,8 @@ func Test_transformMergeRequestEvent(t *testing.T) {
 		hookTransformResult := transformMergeRequestEvent(mergeRequest)
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.EqualError(t, hookTransformResult.Error, "Merge Request already merged")
+		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Merge error")
@@ -347,6 +353,8 @@ func Test_transformMergeRequestEvent(t *testing.T) {
 		hookTransformResult := transformMergeRequestEvent(mergeRequest)
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.EqualError(t, hookTransformResult.Error, "Merge Request is not mergeable")
+		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Not yet merged")

--- a/service/hook/gogs/gogs_test.go
+++ b/service/hook/gogs/gogs_test.go
@@ -72,6 +72,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Do Transform - multiple commits - CheckoutSHA match should trigger the build")
@@ -107,6 +108,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("No commit matches CheckoutSHA")
@@ -126,6 +128,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "The commit specified by 'after' was not included in the 'commits' array - no match found")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Not a head ref")
@@ -145,6 +148,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.EqualError(t, hookTransformResult.Error, "Ref (refs/not/head) is not a head ref")
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 }
 
@@ -188,6 +192,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Unsuported Content-Type")

--- a/service/hook/slack/slack_test.go
+++ b/service/hook/slack/slack_test.go
@@ -203,6 +203,7 @@ func Test_transformOutgoingWebhookMessage(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Should be OK - space between param key&value")
@@ -220,6 +221,7 @@ func Test_transformOutgoingWebhookMessage(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Empty parameter component")
@@ -237,6 +239,7 @@ func Test_transformOutgoingWebhookMessage(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Message parameter")
@@ -255,6 +258,7 @@ func Test_transformOutgoingWebhookMessage(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Commit parameter")
@@ -273,6 +277,7 @@ func Test_transformOutgoingWebhookMessage(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Tag parameter")
@@ -291,6 +296,7 @@ func Test_transformOutgoingWebhookMessage(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Workflow parameter")
@@ -308,6 +314,7 @@ func Test_transformOutgoingWebhookMessage(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Single environment parameter")
@@ -327,6 +334,7 @@ func Test_transformOutgoingWebhookMessage(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Multiple environment parameters, interleaved and spaced keys")
@@ -347,6 +355,7 @@ func Test_transformOutgoingWebhookMessage(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("All parameters - long form")
@@ -368,6 +377,7 @@ func Test_transformOutgoingWebhookMessage(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("All parameters - short form")
@@ -389,6 +399,7 @@ func Test_transformOutgoingWebhookMessage(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Missing branch parameter")
@@ -399,6 +410,7 @@ func Test_transformOutgoingWebhookMessage(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "Missing 'branch' and 'workflow' parameters - at least one of these is required")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 }
 
@@ -428,6 +440,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Unsupported Event Type")

--- a/service/hook/visualstudioteamservices/visualstudioteamservices_test.go
+++ b/service/hook/visualstudioteamservices/visualstudioteamservices_test.go
@@ -279,6 +279,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "Initial (test) event detected, skipping")
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Bad publisher id")
@@ -293,6 +294,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "Not a Team Foundation Server notification, can't start a build")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Bad event type")
@@ -307,6 +309,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "Not a push event, can't start a build")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Empty commits & no refUpdates")
@@ -335,6 +338,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "No 'commits' included in the webhook, can't start a build")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Empty branch information")
@@ -349,6 +353,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "Can't detect branch information (resource.refUpdates is empty), can't start a build")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Badly formatted branch information")
@@ -363,6 +368,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "Unsupported refs/, can't start a build: refs/invalid")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Git.push with one commit")
@@ -385,6 +391,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Git.push with multiple commits - only the first one (latest commit) should be picked")
@@ -407,6 +414,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Git.push - Tag (create)")
@@ -441,6 +449,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Git.push - Tag Delete")
@@ -468,6 +477,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "Tag delete event - does not require a build")
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Git.push - Branch Delete")
@@ -495,6 +505,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		require.EqualError(t, hookTransformResult.Error, "Branch delete event - does not require a build")
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Git.push - Branch Created")
@@ -530,6 +541,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
 	t.Log("Git.push - Pull Request merged (no commit!?!?)")
@@ -573,5 +585,6 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 }


### PR DESCRIPTION
DontWaitForTriggerResponse if true the Trigger API request will be sent,
but the handler won't wait for the response from the Trigger API,
it'll respond immediately after calling the Trigger API
