### PR TITLE
migration to new Gopkg.toml based Heroku def

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,6 +20,14 @@
 #  name = "github.com/x/y"
 #  version = "2.4.0"
 
+# Heroku specific
+# https://github.com/heroku/heroku-buildpack-go#dep-specifics
+[metadata.heroku]
+  root-package = "github.com/bitrise-io/bitrise-webhooks"
+  # go-version = "go1.8.3"
+  # install = [ "./cmd/...", "./foo" ]
+  ensure = "false"
+  # additional-tools = ["github.com/mattes/migrate"]
 
 [[constraint]]
   branch = "master"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -92,8 +92,6 @@ workflows:
             dep ensure -v
             # to do the actual update
             dep ensure -v -update
-            # copy heroku vendor json into vendor/ dir
-            cp ./heroku-vendor.json ./vendor/vendor.json
   publish-release:
     steps:
     - script:

--- a/heroku-vendor.json
+++ b/heroku-vendor.json
@@ -1,7 +1,0 @@
-{
-    "comment": "For other heroku options see: https://devcenter.heroku.com/articles/go-dependencies-via-govendor#build-configuration",
-    "rootPath": "github.com/bitrise-io/bitrise-webhooks",
-    "heroku": {
-        "sync": false
-    }
-}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,7 +1,0 @@
-{
-    "comment": "For other heroku options see: https://devcenter.heroku.com/articles/go-dependencies-via-govendor#build-configuration",
-    "rootPath": "github.com/bitrise-io/bitrise-webhooks",
-    "heroku": {
-        "sync": false
-    }
-}


### PR DESCRIPTION
Heroku now supports Go packages with dep as dependency tool, out of box,
if you declare the heroku metadata in Gopkg.toml.

Old method doesnt even work anymore, so this was a no-brainer :P