### PR TITLE
Bitbucket v2: return default value when X-Attempt-Number header is missing

### DIFF
--- a/service/hook/bitbucketv2/bitbucketv2.go
+++ b/service/hook/bitbucketv2/bitbucketv2.go
@@ -120,7 +120,7 @@ func detectContentTypeAttemptNumberAndEventKey(header http.Header) (string, stri
 
 	attemptNum := header.Get("X-Attempt-Number")
 	if attemptNum == "" {
-		return "", "", "", errors.New("No X-Attempt-Number Header found")
+		attemptNum = "1"
 	}
 
 	return contentType, attemptNum, eventKey, nil

--- a/service/hook/bitbucketv2/bitbucketv2_test.go
+++ b/service/hook/bitbucketv2/bitbucketv2_test.go
@@ -245,10 +245,10 @@ func Test_detectContentTypeAttemptNumberAndEventKey(t *testing.T) {
 			"Content-Type": {"application/json"},
 		}
 		contentType, attemptNum, eventKey, err := detectContentTypeAttemptNumberAndEventKey(header)
-		require.EqualError(t, err, "No X-Attempt-Number Header found")
-		require.Equal(t, "", contentType)
-		require.Equal(t, "", eventKey)
-		require.Equal(t, "", attemptNum)
+		require.NoError(t, err)
+		require.Equal(t, "application/json", contentType)
+		require.Equal(t, "repo:push", eventKey)
+		require.Equal(t, "1", attemptNum)
 	}
 }
 


### PR DESCRIPTION
### New Pull Request Checklist

- [x] Run `go fmt` on your files (e.g. `go fmt ./service/common.go`, or on the whole `service` folder: `go fmt ./service/...`)
- [x] Write tests for your code
  - The tests should cover both "success" and "error" cases.
  - The tests should also check **all the returned variables**, don't ignore any returned value!
  - Ideally the tests should be easily readable, we usually use tests to document our code instead of code comments.
    An example, if you'd write a comment like "Given X this function will return Y" or
    "Beware, if the input is X this function will return Y" then you should implement this as
    a unit test, instead of writing it as a comment.
- [x] If your Pull Request is more than a bug fix you should also check `README.md` and change/add the descriptions there - also
  feel free to add yourself as a contributor if you implement support for a new service ;)
- [x] Before creating the Pull Request you should also run `bitrise run test` with the [Bitrise CLI](https://www.bitrise.io/cli),
  to perform all the automatic checks (which will run on your Pull Request when you open it).


### Summary of Pull Request

I read issue #65 which suggests a small fix to support Bitbucket Server (which I need too), I had 15 minutes to spare so I implemented it. Note that I did not do any research into this but I assume @majodev findings are correct. 
