### PR TITLE
Add support for new branch triggers from Bitbucket Server

### DIFF
--- a/service/hook/bitbucketserver/bitbucketserver.go
+++ b/service/hook/bitbucketserver/bitbucketserver.go
@@ -145,9 +145,9 @@ func transformPushEvent(pushEvent PushEventModel) hookCommon.TransformResultMode
 	triggerAPIParams := []bitriseapi.TriggerAPIParamsModel{}
 	errs := []string{}
 	for _, aChange := range pushEvent.Changes {
-		if pushEvent.RepositoryInfo.Scm == scmGit && aChange.Type == "UPDATE" {
-			if aChange.Ref.Type != "BRANCH" {
-				errs = append(errs, fmt.Sprintf("Ref was not a type=BRANCH. Type was: %s", aChange.Ref.Type))
+		if pushEvent.RepositoryInfo.Scm == scmGit && aChange.Ref.Type == "BRANCH" {
+			if aChange.Type != "ADD" && aChange.Type != "UPDATE" {
+				errs = append(errs, fmt.Sprintf("Not a type=UPDATE nor type=ADD change. Change.Type was: %s", aChange.Type))
 				continue
 			}
 			aTriggerAPIParams := bitriseapi.TriggerAPIParamsModel{
@@ -157,9 +157,9 @@ func transformPushEvent(pushEvent PushEventModel) hookCommon.TransformResultMode
 				},
 			}
 			triggerAPIParams = append(triggerAPIParams, aTriggerAPIParams)
-		} else if aChange.Type == "ADD" { //tag
-			if aChange.Ref.Type != "TAG" {
-				errs = append(errs, fmt.Sprintf("Ref was not a type=TAG. Type was: %s", aChange.Ref.Type))
+		} else if aChange.Ref.Type == "TAG" { //tag
+			if aChange.Type != "ADD" {
+				errs = append(errs, fmt.Sprintf("Not a type=ADD change. Change.Type was: %s", aChange.Type))
 				continue
 			}
 			aTriggerAPIParams := bitriseapi.TriggerAPIParamsModel{
@@ -170,7 +170,7 @@ func transformPushEvent(pushEvent PushEventModel) hookCommon.TransformResultMode
 			}
 			triggerAPIParams = append(triggerAPIParams, aTriggerAPIParams)
 		} else {
-			errs = append(errs, fmt.Sprintf("Not a type=UPDATE nor type=ADD change. Change.Type was: %s", aChange.Type))
+			errs = append(errs, fmt.Sprintf("Ref was not a type=BRANCH nor type=TAG change. Type was: %s", aChange.Ref.Type))
 		}
 	}
 	if len(triggerAPIParams) < 1 {

--- a/service/hook/bitbucketserver/bitbucketserver_test.go
+++ b/service/hook/bitbucketserver/bitbucketserver_test.go
@@ -51,7 +51,7 @@ const (
       "refId":"refs/heads/master",
       "fromHash":"from-hash-1",
       "toHash":"to-hash-1",
-      "type":"UPDATE"
+      "type":"ADD"
     },
  {
       "ref":{
@@ -405,7 +405,7 @@ func Test_transformPushEvent(t *testing.T) {
 			},
 			Changes: []ChangeItemModel{
 				{
-					Type:     "UPDATE",
+					Type:     "ADD",
 					FromHash: "from-hash-1",
 					ToHash:   "to-hash-1",
 					RefID:    "refs/heads/master",
@@ -617,7 +617,7 @@ func Test_transformPushEvent(t *testing.T) {
 			},
 		}
 		hookTransformResult := transformPushEvent(pushEvent)
-		require.EqualError(t, hookTransformResult.Error, "'changes' specified in the webhook, but none can be transformed into a build. Collected errors: [Not a type=UPDATE nor type=ADD change. Change.Type was: INVALID]")
+		require.EqualError(t, hookTransformResult.Error, "'changes' specified in the webhook, but none can be transformed into a build. Collected errors: [Not a type=ADD change. Change.Type was: INVALID]")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
 		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
@@ -671,7 +671,7 @@ func Test_transformPushEvent(t *testing.T) {
 			},
 		}
 		hookTransformResult := transformPushEvent(pushEvent)
-		require.EqualError(t, hookTransformResult.Error, "'changes' specified in the webhook, but none can be transformed into a build. Collected errors: [Ref was not a type=BRANCH. Type was: NOT-BRANCH Ref was not a type=TAG. Type was: NOT-TAG]")
+		require.EqualError(t, hookTransformResult.Error, "'changes' specified in the webhook, but none can be transformed into a build. Collected errors: [Ref was not a type=BRANCH nor type=TAG change. Type was: NOT-BRANCH Ref was not a type=BRANCH nor type=TAG change. Type was: NOT-TAG]")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
 		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)


### PR DESCRIPTION
This pull request fixes a bug causing newly pushed branches on a Bitbucket Server repository not to trigger a build in Bitrise. See issue #69.

Fixes #69