### PR TITLE
GitLab: adds more intuitive merge request event filtering

### DIFF
--- a/service/hook/gitlab/gitlab.go
+++ b/service/hook/gitlab/gitlab.go
@@ -99,7 +99,7 @@ type ObjectAttributesInfoModel struct {
 	MergeStatus    string              `json:"merge_status"`
 	MergeCommitSHA string              `json:"merge_commit_sha"`
 	MergeError     string              `json:"merge_error"`
-	Oldrev	       string              `json:"oldrev"`
+	Oldrev         string              `json:"oldrev"`
 	Source         BranchInfoModel     `json:"source"`
 	SourceBranch   string              `json:"source_branch"`
 	Target         BranchInfoModel     `json:"target"`
@@ -157,8 +157,8 @@ func transformCodePushEvent(codePushEvent CodePushEventModel) hookCommon.Transfo
 	if !strings.HasPrefix(codePushEvent.Ref, "refs/heads/") {
 		return hookCommon.TransformResultModel{
 			DontWaitForTriggerResponse: true,
-			Error:      fmt.Errorf("Ref (%s) is not a head ref", codePushEvent.Ref),
-			ShouldSkip: true,
+			Error:                      fmt.Errorf("Ref (%s) is not a head ref", codePushEvent.Ref),
+			ShouldSkip:                 true,
 		}
 	}
 	branch := strings.TrimPrefix(codePushEvent.Ref, "refs/heads/")
@@ -176,7 +176,7 @@ func transformCodePushEvent(codePushEvent CodePushEventModel) hookCommon.Transfo
 	if !isLastCommitFound {
 		return hookCommon.TransformResultModel{
 			DontWaitForTriggerResponse: true,
-			Error: errors.New("The commit specified by 'checkout_sha' was not included in the 'commits' array - no match found"),
+			Error:                      errors.New("The commit specified by 'checkout_sha' was not included in the 'commits' array - no match found"),
 		}
 	}
 
@@ -198,14 +198,14 @@ func transformTagPushEvent(tagPushEvent TagPushEventModel) hookCommon.TransformR
 	if tagPushEvent.ObjectKind != "tag_push" {
 		return hookCommon.TransformResultModel{
 			DontWaitForTriggerResponse: true,
-			Error: fmt.Errorf("Not a Tag Push object: %s", tagPushEvent.ObjectKind),
+			Error:                      fmt.Errorf("Not a Tag Push object: %s", tagPushEvent.ObjectKind),
 		}
 	}
 
 	if !strings.HasPrefix(tagPushEvent.Ref, "refs/tags/") {
 		return hookCommon.TransformResultModel{
 			DontWaitForTriggerResponse: true,
-			Error: fmt.Errorf("Ref (%s) is not a tags ref", tagPushEvent.Ref),
+			Error:                      fmt.Errorf("Ref (%s) is not a tags ref", tagPushEvent.Ref),
 		}
 	}
 	tag := strings.TrimPrefix(tagPushEvent.Ref, "refs/tags/")
@@ -213,8 +213,8 @@ func transformTagPushEvent(tagPushEvent TagPushEventModel) hookCommon.TransformR
 	if len(tagPushEvent.CheckoutSHA) < 1 {
 		return hookCommon.TransformResultModel{
 			DontWaitForTriggerResponse: true,
-			Error:      errors.New("This is a Tag Deleted event, no build is required"),
-			ShouldSkip: true,
+			Error:                      errors.New("This is a Tag Deleted event, no build is required"),
+			ShouldSkip:                 true,
 		}
 	}
 
@@ -235,48 +235,48 @@ func transformMergeRequestEvent(mergeRequest MergeRequestEventModel) hookCommon.
 	if mergeRequest.ObjectKind != "merge_request" {
 		return hookCommon.TransformResultModel{
 			DontWaitForTriggerResponse: true,
-			Error:      errors.New("Not a Merge Request object"),
-			ShouldSkip: true,
+			Error:                      errors.New("Not a Merge Request object"),
+			ShouldSkip:                 true,
 		}
 	}
 
 	if mergeRequest.ObjectAttributes.State == "" {
 		return hookCommon.TransformResultModel{
 			DontWaitForTriggerResponse: true,
-			Error:      errors.New("No Merge Request state specified"),
-			ShouldSkip: true,
+			Error:                      errors.New("No Merge Request state specified"),
+			ShouldSkip:                 true,
 		}
 	}
 
 	if mergeRequest.ObjectAttributes.MergeCommitSHA != "" {
 		return hookCommon.TransformResultModel{
 			DontWaitForTriggerResponse: true,
-			Error:      errors.New("Merge Request already merged"),
-			ShouldSkip: true,
+			Error:                      errors.New("Merge Request already merged"),
+			ShouldSkip:                 true,
 		}
 	}
 
 	if !isAcceptMergeRequestState(mergeRequest.ObjectAttributes.State) {
 		return hookCommon.TransformResultModel{
 			DontWaitForTriggerResponse: true,
-			Error:      fmt.Errorf("Merge Request state doesn't require a build: %s", mergeRequest.ObjectAttributes.State),
-			ShouldSkip: true,
+			Error:                      fmt.Errorf("Merge Request state doesn't require a build: %s", mergeRequest.ObjectAttributes.State),
+			ShouldSkip:                 true,
 		}
 	}
 
 	if !isAcceptMergeRequestAction(mergeRequest.ObjectAttributes.Action, mergeRequest.ObjectAttributes.Oldrev) {
 		return hookCommon.TransformResultModel{
 			DontWaitForTriggerResponse: true,
-			Error:      fmt.Errorf("Merge Request action doesn't require a build: %s", mergeRequest.ObjectAttributes.Action),
-			ShouldSkip: true,
+			Error:                      fmt.Errorf("Merge Request action doesn't require a build: %s", mergeRequest.ObjectAttributes.Action),
+			ShouldSkip:                 true,
 		}
 	}
 
 	if mergeRequest.ObjectAttributes.MergeStatus == "cannot_be_merged" || mergeRequest.ObjectAttributes.MergeError != "" {
 		return hookCommon.TransformResultModel{
 			DontWaitForTriggerResponse: true,
-			Error:      errors.New("Merge Request is not mergeable"),
-			ShouldSkip: true,
+			Error:                      errors.New("Merge Request is not mergeable"),
+			ShouldSkip:                 true,
 		}
 	}
 
@@ -309,14 +309,14 @@ func (hp HookProvider) TransformRequest(r *http.Request) hookCommon.TransformRes
 	if err != nil {
 		return hookCommon.TransformResultModel{
 			DontWaitForTriggerResponse: true,
-			Error: fmt.Errorf("Issue with Headers: %s", err),
+			Error:                      fmt.Errorf("Issue with Headers: %s", err),
 		}
 	}
 
 	if contentType != "application/json" {
 		return hookCommon.TransformResultModel{
 			DontWaitForTriggerResponse: true,
-			Error: fmt.Errorf("Content-Type is not supported: %s", contentType),
+			Error:                      fmt.Errorf("Content-Type is not supported: %s", contentType),
 		}
 	}
 
@@ -324,14 +324,14 @@ func (hp HookProvider) TransformRequest(r *http.Request) hookCommon.TransformRes
 		// Unsupported Event
 		return hookCommon.TransformResultModel{
 			DontWaitForTriggerResponse: true,
-			Error: fmt.Errorf("Unsupported Webhook event: %s", eventID),
+			Error:                      fmt.Errorf("Unsupported Webhook event: %s", eventID),
 		}
 	}
 
 	if r.Body == nil {
 		return hookCommon.TransformResultModel{
 			DontWaitForTriggerResponse: true,
-			Error: fmt.Errorf("Failed to read content of request body: no or empty request body"),
+			Error:                      fmt.Errorf("Failed to read content of request body: no or empty request body"),
 		}
 	}
 
@@ -342,7 +342,7 @@ func (hp HookProvider) TransformRequest(r *http.Request) hookCommon.TransformRes
 			if err := json.NewDecoder(r.Body).Decode(&codePushEvent); err != nil {
 				return hookCommon.TransformResultModel{
 					DontWaitForTriggerResponse: true,
-					Error: fmt.Errorf("Failed to parse request body: %s", err)}
+					Error:                      fmt.Errorf("Failed to parse request body: %s", err)}
 			}
 		}
 		return transformCodePushEvent(codePushEvent)
@@ -353,7 +353,7 @@ func (hp HookProvider) TransformRequest(r *http.Request) hookCommon.TransformRes
 			if err := json.NewDecoder(r.Body).Decode(&tagPushEvent); err != nil {
 				return hookCommon.TransformResultModel{
 					DontWaitForTriggerResponse: true,
-					Error: fmt.Errorf("Failed to parse request body: %s", err)}
+					Error:                      fmt.Errorf("Failed to parse request body: %s", err)}
 			}
 		}
 		return transformTagPushEvent(tagPushEvent)
@@ -362,7 +362,7 @@ func (hp HookProvider) TransformRequest(r *http.Request) hookCommon.TransformRes
 		if err := json.NewDecoder(r.Body).Decode(&mergeRequestEvent); err != nil {
 			return hookCommon.TransformResultModel{
 				DontWaitForTriggerResponse: true,
-				Error: fmt.Errorf("Failed to parse request body as JSON: %s", err)}
+				Error:                      fmt.Errorf("Failed to parse request body as JSON: %s", err)}
 		}
 
 		return transformMergeRequestEvent(mergeRequestEvent)
@@ -370,6 +370,6 @@ func (hp HookProvider) TransformRequest(r *http.Request) hookCommon.TransformRes
 
 	return hookCommon.TransformResultModel{
 		DontWaitForTriggerResponse: true,
-		Error: fmt.Errorf("Unsupported GitLab event type: %s", eventID),
+		Error:                      fmt.Errorf("Unsupported GitLab event type: %s", eventID),
 	}
 }

--- a/service/hook/gitlab/gitlab_test.go
+++ b/service/hook/gitlab/gitlab_test.go
@@ -383,8 +383,8 @@ func Test_transformMergeRequestEvent(t *testing.T) {
 		mergeRequest := MergeRequestEventModel{
 			ObjectKind: "merge_request",
 			ObjectAttributes: ObjectAttributesInfoModel{
-				State:      "opened",
-				Action:     "approved",
+				State:  "opened",
+				Action: "approved",
 			},
 		}
 		hookTransformResult := transformMergeRequestEvent(mergeRequest)
@@ -399,8 +399,8 @@ func Test_transformMergeRequestEvent(t *testing.T) {
 		mergeRequest := MergeRequestEventModel{
 			ObjectKind: "merge_request",
 			ObjectAttributes: ObjectAttributesInfoModel{
-				State:      "opened",
-				Action:     "update",
+				State:  "opened",
+				Action: "update",
 			},
 		}
 		hookTransformResult := transformMergeRequestEvent(mergeRequest)

--- a/service/hook/gitlab/gitlab_test.go
+++ b/service/hook/gitlab/gitlab_test.go
@@ -32,7 +32,7 @@ const sampleMergeRequestData = `{
 "object_kind": "merge_request",
 "object_attributes": {
 	"target_branch": "develop",
-	"source_branch": "feature/github-pr",
+	"source_branch": "feature/gitlab-pr",
 	"title": "PR test",
 	"merge_status": "unchecked",
 	"iid": 12,
@@ -53,6 +53,7 @@ const sampleMergeRequestData = `{
 		"id": "da966425f32973b6290dcff6a443103c7ff2a8cb"
 	},
 	"action": "update",
+	"oldrev": "3c86b996d8014000a93f3c202fc0963e81e56c4c",
 	"state": "opened"
 }}`
 
@@ -347,6 +348,8 @@ func Test_transformMergeRequestEvent(t *testing.T) {
 			ObjectKind: "merge_request",
 			ObjectAttributes: ObjectAttributesInfoModel{
 				State:      "opened",
+				Action:     "update",
+				Oldrev:     "83b86e5f286f546dc5a4a58db66ceef44460c85e",
 				MergeError: "Some merge error",
 			},
 		}
@@ -357,23 +360,74 @@ func Test_transformMergeRequestEvent(t *testing.T) {
 		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
+	t.Log("Not mergeable")
+	{
+		mergeRequest := MergeRequestEventModel{
+			ObjectKind: "merge_request",
+			ObjectAttributes: ObjectAttributesInfoModel{
+				State:       "opened",
+				Action:      "update",
+				Oldrev:      "83b86e5f286f546dc5a4a58db66ceef44460c85e",
+				MergeStatus: "cannot_be_merged",
+			},
+		}
+		hookTransformResult := transformMergeRequestEvent(mergeRequest)
+		require.True(t, hookTransformResult.ShouldSkip)
+		require.EqualError(t, hookTransformResult.Error, "Merge Request is not mergeable")
+		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
+	}
+
+	t.Log("Irrelevant action")
+	{
+		mergeRequest := MergeRequestEventModel{
+			ObjectKind: "merge_request",
+			ObjectAttributes: ObjectAttributesInfoModel{
+				State:      "opened",
+				Action:     "approved",
+			},
+		}
+		hookTransformResult := transformMergeRequestEvent(mergeRequest)
+		require.True(t, hookTransformResult.ShouldSkip)
+		require.EqualError(t, hookTransformResult.Error, "Merge Request action doesn't require a build: approved")
+		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
+	}
+
+	t.Log("Irrelevant update")
+	{
+		mergeRequest := MergeRequestEventModel{
+			ObjectKind: "merge_request",
+			ObjectAttributes: ObjectAttributesInfoModel{
+				State:      "opened",
+				Action:     "update",
+			},
+		}
+		hookTransformResult := transformMergeRequestEvent(mergeRequest)
+		require.True(t, hookTransformResult.ShouldSkip)
+		require.EqualError(t, hookTransformResult.Error, "Merge Request action doesn't require a build: update")
+		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
+	}
+
 	t.Log("Not yet merged")
 	{
 		mergeRequest := MergeRequestEventModel{
 			ObjectKind: "merge_request",
 			ObjectAttributes: ObjectAttributesInfoModel{
-				ID:    12,
-				Title: "PR test",
-				State: "opened",
+				ID:     12,
+				Title:  "PR test",
+				State:  "opened",
+				Action: "open",
 				Source: BranchInfoModel{
 					VisibilityLevel: 20,
-					GitSSHURL:       "git@github.com:bitrise-io/bitrise-webhooks.git",
+					GitSSHURL:       "git@gitlab.com:bitrise-io/bitrise-webhooks.git",
 					GitHTTPURL:      "https://gitlab.com/bitrise-io/bitrise-webhooks.git",
 				},
 				SourceBranch: "feature/gitlab-pr",
 				Target: BranchInfoModel{
 					VisibilityLevel: 20,
-					GitSSHURL:       "git@github.com:bitrise-io/bitrise-webhooks.git",
+					GitSSHURL:       "git@gitlab.com:bitrise-io/bitrise-webhooks.git",
 					GitHTTPURL:      "https://gitlab.com/bitrise-io/bitrise-webhooks.git",
 				},
 				TargetBranch: "master",
@@ -411,15 +465,16 @@ func Test_transformMergeRequestEvent(t *testing.T) {
 				Title:       "PR test",
 				Description: "PR test body",
 				State:       "opened",
+				Action:      "open",
 				Source: BranchInfoModel{
 					VisibilityLevel: 20,
-					GitSSHURL:       "git@github.com:bitrise-io/bitrise-webhooks.git",
+					GitSSHURL:       "git@gitlab.com:bitrise-io/bitrise-webhooks.git",
 					GitHTTPURL:      "https://gitlab.com/bitrise-io/bitrise-webhooks.git",
 				},
 				SourceBranch: "feature/gitlab-pr",
 				Target: BranchInfoModel{
 					VisibilityLevel: 20,
-					GitSSHURL:       "git@github.com:bitrise-io/bitrise-webhooks.git",
+					GitSSHURL:       "git@gitlab.com:bitrise-io/bitrise-webhooks.git",
 					GitHTTPURL:      "https://gitlab.com/bitrise-io/bitrise-webhooks.git",
 				},
 				TargetBranch: "master",
@@ -600,7 +655,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 				BuildParams: bitriseapi.BuildParamsModel{
 					CommitHash:               "da966425f32973b6290dcff6a443103c7ff2a8cb",
 					CommitMessage:            "PR test\n\nPR text body",
-					Branch:                   "feature/github-pr",
+					Branch:                   "feature/gitlab-pr",
 					BranchDest:               "develop",
 					PullRequestID:            pointers.NewIntPtr(12),
 					PullRequestRepositoryURL: "https://gitlab.com/bitrise-io/bitrise-webhooks.git",


### PR DESCRIPTION
### New Pull Request Checklist

- [x] Run `go fmt` on your files (e.g. `go fmt ./service/common.go`, or on the whole `service` folder: `go fmt ./service/...`)
- [x] Write tests for your code
  - The tests should cover both "success" and "error" cases.
  - The tests should also check **all the returned variables**, don't ignore any returned value!
  - Ideally the tests should be easily readable, we usually use tests to document our code instead of code comments.
    An example, if you'd write a comment like "Given X this function will return Y" or
    "Beware, if the input is X this function will return Y" then you should implement this as
    a unit test, instead of writing it as a comment.
- [ ] If your Pull Request is more than a bug fix you should also check `README.md` and change/add the descriptions there - also
  feel free to add yourself as a contributor if you implement support for a new service ;)
- [ ] Before creating the Pull Request you should also run `bitrise run test` with the [Bitrise CLI](https://www.bitrise.io/cli),
  to perform all the automatic checks (which will run on your Pull Request when you open it).

### Summary of Pull Request

Today, the GitLab webhook doesn't take into account the ["`action`" type](https://docs.gitlab.com/ee/api/events.html#action-types) on merge request events. The side effect is that every [merge request event](https://gitlab.com/help/user/project/integrations/webhooks#merge-request-events) received with the ["`state`" of `"opened"` or `"reopened"`](https://github.com/bitrise-io/bitrise-webhooks/blob/67df993abfc6728dd8478805358e0eecee4c35f3/service/hook/gitlab/gitlab.go#L138) is passed along to workflows' pull request triggers regardless of the relevance of the actual `"action"` appearing in the payload. This in turn can clog build queues and waste lots of precious time and money for any Bitrise user that hosts their projects on GitLab. 💸

To fix this, I've added some additional logic that checks the merge request "action" (along with the "state"), and skips event propagation accordingly.

Specifically, this adds the following updates to hook logic for merge requests:
* Checks `action` and skips irrelevant updates
* Adds a `merge_status` check to skip non-mergeable branches

Also:
* Updates links to official GitLab webhook docs
* Some other very minor cosmetic/pedantic changes

Closes gh-81.