### PR TITLE
Add support for tag Webhook triggers in Gogs/Gitea.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If the (commit) message includes `[skip ci]` or `[ci skip]` no build will be tri
   * handled on the path: `/h/visualstudio/BITRISE-APP-SLUG/BITRISE-APP-API-TOKEN`
 * [GitLab](https://gitlab.com)
   * handled on the path: `/h/gitlab/BITRISE-APP-SLUG/BITRISE-APP-API-TOKEN`
-* [Gogs](https://gogs.io)
+* [Gogs](https://gogs.io) or [Gitea](https://gitea.io)
   * handled on the path: `/h/gogs/BITRISE-APP-SLUG/BITRISE-APP-API-TOKEN`
 * [Deveo](https://deveo.com)
   * handled on the path: `/h/deveo/BITRISE-APP-SLUG/BITRISE-APP-API-TOKEN`
@@ -120,7 +120,8 @@ a build will be triggered (if you have Trigger mapping defined for the event(s) 
 
 ### Gogs - setup & usage:
 
-All you have to do is register your `bitrise-webhooks` URL as a Webhook in your [Gogs](https://gogs.io) repository.
+All you have to do is register your `bitrise-webhooks` URL as a Webhook in your [Gogs](https://gogs.io)
+or [Gitea](https://gitea.io) repository. (Both repositories use the same Webhook format.)
 
 1. Open your *project* on your repository's hosting URL.
 1. Go to `Settings` of the *project*
@@ -128,7 +129,8 @@ All you have to do is register your `bitrise-webhooks` URL as a Webhook in your 
 1. Specify the `bitrise-webhooks` URL (`.../h/gogs/BITRISE-APP-SLUG/BITRISE-APP-API-TOKEN`) in the `Payload URL` field.
 1. Set the `Content Type` to `application/json`.
 1. A Secret is not required at this time.
-1. Set the trigger to be fired on `Just the push event`
+1. Set the trigger to be fired on either `Just the push event` or `Let me choose what I need` and select
+`Create` and `Push`. (Pull request triggers are not supported at this time.)
 1. Save the Webhook.
 
 That's all! The next time you __push code__

--- a/service/hook/gogs/gogs.go
+++ b/service/hook/gogs/gogs.go
@@ -42,6 +42,7 @@ type PushEventModel struct {
 	Commits     []CommitModel `json:"commits"`
 }
 
+// TagEventModel ...
 type TagEventModel struct {
 	Secret  string `json:"secret"`
 	Ref     string `json:"ref"`

--- a/service/hook/gogs/gogs.go
+++ b/service/hook/gogs/gogs.go
@@ -70,6 +70,12 @@ func detectContentTypeAndEventID(header http.Header) (string, string, error) {
 }
 
 func transformPushEvent(pushEvent PushEventModel) hookCommon.TransformResultModel {
+	if strings.HasPrefix(pushEvent.Ref, "refs/tags/") {
+		return hookCommon.TransformResultModel{
+			ShouldSkip: true,
+		}
+	}
+
 	lastCommit := CommitModel{}
 	isLastCommitFound := false
 	for _, aCommit := range pushEvent.Commits {
@@ -89,6 +95,12 @@ func transformPushEvent(pushEvent PushEventModel) hookCommon.TransformResultMode
 	if len(lastCommit.CommitHash) == 0 {
 		return hookCommon.TransformResultModel{
 			Error: fmt.Errorf("Missing commit hash"),
+		}
+	}
+
+	if !strings.HasPrefix(pushEvent.Ref, "refs/heads/") {
+		return hookCommon.TransformResultModel{
+			Error: fmt.Errorf("Ref (%s) is not a head ref", pushEvent.Ref),
 		}
 	}
 

--- a/service/hook/gogs/gogs_test.go
+++ b/service/hook/gogs/gogs_test.go
@@ -133,7 +133,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 
 	t.Log("Not a head ref")
 	{
-		codePush := CodePushEventModel{
+		codePush := PushEventModel{
 			Secret:      "",
 			Ref:         "refs/not/head",
 			CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
@@ -144,8 +144,22 @@ func Test_transformCodePushEvent(t *testing.T) {
 				},
 			},
 		}
-		hookTransformResult := transformCodePushEvent(codePush)
+		hookTransformResult := transformPushEvent(codePush)
+		require.EqualError(t, hookTransformResult.Error, "Ref (refs/not/head) is not a head ref")
 		require.False(t, hookTransformResult.ShouldSkip)
+		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
+	}
+
+	t.Log("Is a tag ref")
+	{
+		codePush := PushEventModel{
+			Secret:      "",
+			Ref:         "refs/tags/1.0.0",
+			CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
+		}
+		hookTransformResult := transformPushEvent(codePush)
+		require.True(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
 		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}


### PR DESCRIPTION
This PR (continues #43) addresses #30 with two changes:

Adds support for Tag triggers, which are sent as ref_type: "tag", ref: "TAGNAME".
Adds doc references to Gitea, which the GOGS handler is compatible with (since Gitea is a GOGS fork).