### PR TITLE
#72 Bitbucket Server: handle the initial ping hook sent when you add …

### DIFF
--- a/service/hook/bitbucketserver/bitbucketserver.go
+++ b/service/hook/bitbucketserver/bitbucketserver.go
@@ -211,7 +211,7 @@ func transformPullRequestEvent(pullRequest PullRequestEventModel) hookCommon.Tra
 }
 
 func isAcceptEventType(eventKey string) bool {
-	return sliceutil.IsStringInSlice(eventKey, []string{"repo:refs_changed", "pr:opened"})
+	return sliceutil.IsStringInSlice(eventKey, []string{"repo:refs_changed", "pr:opened", "diagnostics:ping"})
 }
 
 // TransformRequest ...
@@ -261,6 +261,11 @@ func (hp HookProvider) TransformRequest(r *http.Request) hookCommon.TransformRes
 		}
 
 		return transformPullRequestEvent(pullRequestEvent)
+	} else if eventKey == "diagnostics:ping" {
+		return hookCommon.TransformResultModel{
+			ShouldSkip: true,
+			Error:      fmt.Errorf("Bitbucket event type: %s is successful", eventKey),
+		}
 	}
 
 	return hookCommon.TransformResultModel{

--- a/service/hook/bitbucketserver/bitbucketserver.go
+++ b/service/hook/bitbucketserver/bitbucketserver.go
@@ -265,7 +265,7 @@ func (hp HookProvider) TransformRequest(r *http.Request) hookCommon.TransformRes
 		return transformPullRequestEvent(pullRequestEvent)
 	}
   
-  if eventKey == "diagnostics:ping" {
+	if eventKey == "diagnostics:ping" {
 		return hookCommon.TransformResultModel{
 			ShouldSkip: true,
 			Error:      fmt.Errorf("Bitbucket event type: %s is successful", eventKey),

--- a/service/hook/bitbucketserver/bitbucketserver_test.go
+++ b/service/hook/bitbucketserver/bitbucketserver_test.go
@@ -198,6 +198,10 @@ const (
     }
   }
 }`
+
+	samplePingData = `{
+	"test": true
+}`
 )
 
 func Test_detectContentTypeSecretAndEventKey(t *testing.T) {
@@ -824,6 +828,25 @@ func Test_isAcceptEventType(t *testing.T) {
 			t.Log(" * " + anAction)
 			require.Equal(t, false, isAcceptEventType(anAction))
 		}
+	}
+}
+
+func Test_transformPingEvent(t *testing.T) {
+	provider := HookProvider{}
+
+	t.Log("Bitbucket Server Ping")
+	{
+		request := http.Request{
+			Header: http.Header{
+				"X-Event-Key":  {"diagnostics:ping"},
+				"Content-Type": {"application/json; charset=utf-8"},
+				"X-Request-Id": {"009af3f7-21ef-4806-8649-e6916498ab0f"},
+			},
+			Body: ioutil.NopCloser(strings.NewReader(samplePingData)),
+		}
+		hookTransformResult := provider.TransformRequest(&request)
+		require.True(t, hookTransformResult.ShouldSkip)
+		require.EqualError(t, hookTransformResult.Error, "Bitbucket event type: diagnostics:ping is successful")
 	}
 }
 


### PR DESCRIPTION
…a webhook in Bitbucket Server

### New Pull Request Checklist

- [ OK ] Run `go fmt` on your files (e.g. `go fmt ./service/common.go`, or on the whole `service` folder: `go fmt ./service/...`)
- [ OK ] Write tests for your code  
- [ NA ] If your Pull Request is more than a bug fix you should also check `README.md` and change/add the descriptions there - also
  feel free to add yourself as a contributor if you implement support for a new service ;)
- [ OK ] Before creating the Pull Request you should also run `bitrise run test` with the [Bitrise CLI](https://www.bitrise.io/cli),
  to perform all the automatic checks (which will run on your Pull Request when you open it).


### Summary of Pull Request

This PR adds support for bitbucket server ping - [https://github.com/bitrise-io/bitrise-webhooks/issues/72]