### PR TITLE
Merge: Add support for tag Webhook triggers in Gogs/Gitea #91

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ If the (commit) message includes `[skip ci]` or `[ci skip]` no build will be tri
   * handled on the path: `/h/visualstudio/BITRISE-APP-SLUG/BITRISE-APP-API-TOKEN`
 * [GitLab](https://gitlab.com)
   * handled on the path: `/h/gitlab/BITRISE-APP-SLUG/BITRISE-APP-API-TOKEN`
-* [Gogs](https://gogs.io)
+* [Gogs](https://gogs.io) or [Gitea](https://gitea.io)
   * handled on the path: `/h/gogs/BITRISE-APP-SLUG/BITRISE-APP-API-TOKEN`
 * [Deveo](https://deveo.com)
   * handled on the path: `/h/deveo/BITRISE-APP-SLUG/BITRISE-APP-API-TOKEN`
@@ -117,7 +117,8 @@ a build will be triggered (if you have Trigger mapping defined for the event(s) 
 
 ### Gogs - setup & usage:
 
-All you have to do is register your `bitrise-webhooks` URL as a Webhook in your [Gogs](https://gogs.io) repository.
+All you have to do is register your `bitrise-webhooks` URL as a Webhook in your [Gogs](https://gogs.io)
+or [Gitea](https://gitea.io) repository. (Both repositories use the same Webhook format.)
 
 1. Open your *project* on your repository's hosting URL.
 1. Go to `Settings` of the *project*
@@ -125,7 +126,8 @@ All you have to do is register your `bitrise-webhooks` URL as a Webhook in your 
 1. Specify the `bitrise-webhooks` URL (`.../h/gogs/BITRISE-APP-SLUG/BITRISE-APP-API-TOKEN`) in the `Payload URL` field.
 1. Set the `Content Type` to `application/json`.
 1. A Secret is not required at this time.
-1. Set the trigger to be fired on `Just the push event`
+1. Set the trigger to be fired on either `Just the push event` or `Let me choose what I need` and select
+`Create` and `Push`. (Pull request triggers are not supported at this time.)
 1. Save the Webhook.
 
 That's all! The next time you __push code__

--- a/service/hook/gogs/gogs.go
+++ b/service/hook/gogs/gogs.go
@@ -36,7 +36,6 @@ type CommitModel struct {
 
 // PushEventModel ...
 type PushEventModel struct {
-	Secret      string        `json:"secret"`
 	Ref         string        `json:"ref"`
 	CheckoutSHA string        `json:"after"`
 	Commits     []CommitModel `json:"commits"`
@@ -44,7 +43,6 @@ type PushEventModel struct {
 
 // CreateEventModel ...
 type CreateEventModel struct {
-	Secret  string `json:"secret"`
 	Ref     string `json:"ref"`
 	RefType string `json:"ref_type"`
 }
@@ -72,6 +70,7 @@ func detectContentTypeAndEventID(header http.Header) (string, string, error) {
 func transformPushEvent(pushEvent PushEventModel) hookCommon.TransformResultModel {
 	if strings.HasPrefix(pushEvent.Ref, "refs/tags/") {
 		return hookCommon.TransformResultModel{
+			Error:      fmt.Errorf("Ref (%s) is a tag ref", pushEvent.Ref),
 			ShouldSkip: true,
 		}
 	}

--- a/service/hook/gogs/gogs.go
+++ b/service/hook/gogs/gogs.go
@@ -24,7 +24,8 @@ import (
 // --- Webhook Data Model ---
 
 const (
-	pushEventID = "push"
+	pushEventID   = "push"
+	createEventID = "create"
 )
 
 // CommitModel ...
@@ -33,12 +34,19 @@ type CommitModel struct {
 	CommitMessage string `json:"message"`
 }
 
-// CodePushEventModel ...
-type CodePushEventModel struct {
+// PushEventModel ...
+type PushEventModel struct {
 	Secret      string        `json:"secret"`
 	Ref         string        `json:"ref"`
 	CheckoutSHA string        `json:"after"`
 	Commits     []CommitModel `json:"commits"`
+}
+
+// CreateEventModel ...
+type CreateEventModel struct {
+	Secret  string `json:"secret"`
+	Ref     string `json:"ref"`
+	RefType string `json:"ref_type"`
 }
 
 // ---------------------------------------
@@ -61,19 +69,17 @@ func detectContentTypeAndEventID(header http.Header) (string, string, error) {
 	return contentType, eventID, nil
 }
 
-func transformCodePushEvent(codePushEvent CodePushEventModel) hookCommon.TransformResultModel {
-	if !strings.HasPrefix(codePushEvent.Ref, "refs/heads/") {
+func transformPushEvent(pushEvent PushEventModel) hookCommon.TransformResultModel {
+	if strings.HasPrefix(pushEvent.Ref, "refs/tags/") {
 		return hookCommon.TransformResultModel{
-			Error:      fmt.Errorf("Ref (%s) is not a head ref", codePushEvent.Ref),
 			ShouldSkip: true,
 		}
 	}
-	branch := strings.TrimPrefix(codePushEvent.Ref, "refs/heads/")
 
 	lastCommit := CommitModel{}
 	isLastCommitFound := false
-	for _, aCommit := range codePushEvent.Commits {
-		if aCommit.CommitHash == codePushEvent.CheckoutSHA {
+	for _, aCommit := range pushEvent.Commits {
+		if aCommit.CommitHash == pushEvent.CheckoutSHA {
 			isLastCommitFound = true
 			lastCommit = aCommit
 			break
@@ -86,13 +92,49 @@ func transformCodePushEvent(codePushEvent CodePushEventModel) hookCommon.Transfo
 		}
 	}
 
+	if len(lastCommit.CommitHash) == 0 {
+		return hookCommon.TransformResultModel{
+			Error: fmt.Errorf("Missing commit hash"),
+		}
+	}
+
+	if !strings.HasPrefix(pushEvent.Ref, "refs/heads/") {
+		return hookCommon.TransformResultModel{
+			Error: fmt.Errorf("Ref (%s) is not a head ref", pushEvent.Ref),
+		}
+	}
+
+	branch := strings.TrimPrefix(pushEvent.Ref, "refs/heads/")
+
 	return hookCommon.TransformResultModel{
 		TriggerAPIParams: []bitriseapi.TriggerAPIParamsModel{
 			{
 				BuildParams: bitriseapi.BuildParamsModel{
+					Branch:        branch,
 					CommitHash:    lastCommit.CommitHash,
 					CommitMessage: lastCommit.CommitMessage,
-					Branch:        branch,
+				},
+			},
+		},
+	}
+}
+
+func transformCreateEvent(createEvent CreateEventModel) hookCommon.TransformResultModel {
+	// Currently, we only support tag creation, not branches. Even if we wanted branch creation
+	// to trigger a build we would have to wait for https://github.com/go-gitea/gitea/issues/286
+	// to be in both Gogs and Gitea core, and well adopted/distributed.
+	if createEvent.RefType != "tag" {
+		return hookCommon.TransformResultModel{
+			Error:      errors.New("Ignoring branch-create request"),
+			ShouldSkip: true,
+		}
+	}
+
+	return hookCommon.TransformResultModel{
+		TriggerAPIParams: []bitriseapi.TriggerAPIParamsModel{
+			{
+				BuildParams: bitriseapi.BuildParamsModel{
+					Tag: createEvent.Ref,
 				},
 			},
 		},
@@ -108,16 +150,9 @@ func (hp HookProvider) TransformRequest(r *http.Request) hookCommon.TransformRes
 		}
 	}
 
-	if contentType != "application/json" {
+	if contentType != hookCommon.ContentTypeApplicationJSON {
 		return hookCommon.TransformResultModel{
 			Error: fmt.Errorf("Content-Type is not supported: %s", contentType),
-		}
-	}
-
-	if eventID != "push" {
-		// Unsupported Event
-		return hookCommon.TransformResultModel{
-			Error: fmt.Errorf("Unsupported Webhook event: %s", eventID),
 		}
 	}
 
@@ -127,12 +162,25 @@ func (hp HookProvider) TransformRequest(r *http.Request) hookCommon.TransformRes
 		}
 	}
 
-	// code push
-	var codePushEvent CodePushEventModel
-	if contentType == "application/json" {
-		if err := json.NewDecoder(r.Body).Decode(&codePushEvent); err != nil {
+	if eventID == pushEventID {
+		var pushEvent PushEventModel
+		if err := json.NewDecoder(r.Body).Decode(&pushEvent); err != nil {
 			return hookCommon.TransformResultModel{Error: fmt.Errorf("Failed to parse request body: %s", err)}
 		}
+
+		return transformPushEvent(pushEvent)
+
+	} else if eventID == createEventID {
+		var createEvent CreateEventModel
+		if err := json.NewDecoder(r.Body).Decode(&createEvent); err != nil {
+			return hookCommon.TransformResultModel{Error: fmt.Errorf("Failed to parse request body: %s", err)}
+		}
+
+		return transformCreateEvent(createEvent)
 	}
-	return transformCodePushEvent(codePushEvent)
+
+	// Unsupported Event
+	return hookCommon.TransformResultModel{
+		Error: fmt.Errorf("Unsupported Webhook event: %s", eventID),
+	}
 }

--- a/service/hook/gogs/gogs_test.go
+++ b/service/hook/gogs/gogs_test.go
@@ -50,7 +50,6 @@ func Test_transformCodePushEvent(t *testing.T) {
 	t.Log("Do Transform - single commit")
 	{
 		codePush := PushEventModel{
-			Secret:      "",
 			Ref:         "refs/heads/master",
 			CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
 			Commits: []CommitModel{
@@ -78,7 +77,6 @@ func Test_transformCodePushEvent(t *testing.T) {
 	t.Log("Do Transform - multiple commits - CheckoutSHA match should trigger the build")
 	{
 		codePush := PushEventModel{
-			Secret:      "",
 			Ref:         "refs/heads/master",
 			CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
 			Commits: []CommitModel{
@@ -114,7 +112,6 @@ func Test_transformCodePushEvent(t *testing.T) {
 	t.Log("No commit matches CheckoutSHA")
 	{
 		codePush := PushEventModel{
-			Secret:      "",
 			Ref:         "refs/heads/master",
 			CheckoutSHA: "checkout-sha",
 			Commits: []CommitModel{
@@ -134,7 +131,6 @@ func Test_transformCodePushEvent(t *testing.T) {
 	t.Log("Not a head ref")
 	{
 		codePush := PushEventModel{
-			Secret:      "",
 			Ref:         "refs/not/head",
 			CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
 			Commits: []CommitModel{
@@ -154,7 +150,6 @@ func Test_transformCodePushEvent(t *testing.T) {
 	t.Log("Is a tag ref")
 	{
 		codePush := PushEventModel{
-			Secret:      "",
 			Ref:         "refs/tags/1.0.0",
 			CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
 		}

--- a/service/hook/gogs/gogs_test.go
+++ b/service/hook/gogs/gogs_test.go
@@ -182,7 +182,9 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 	const sampleTagPushData = `{
   "secret": "",
   "ref": "v1.12",
-  "ref_type": "tag"
+  "ref_type": "tag",
+  "id":"commithash",
+  "message":"Simple message"
 }`
 
 	const sampleBranchCreatePushData = `{
@@ -230,7 +232,9 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
 			{
 				BuildParams: bitriseapi.BuildParamsModel{
-					Tag: "v1.12",
+					Tag:           "v1.12",
+					CommitHash:    "commithash",
+					CommitMessage: "Simple message",
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
@@ -247,7 +251,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		}
 		hookTransformResult := provider.TransformRequest(&request)
 		require.True(t, hookTransformResult.ShouldSkip)
-		require.EqualError(t, hookTransformResult.Error, "Ignoring branch-create request")
+		require.EqualError(t, hookTransformResult.Error, "Not a tag create event - ignoring")
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
 	}
 

--- a/service/hook/gogs/gogs_test.go
+++ b/service/hook/gogs/gogs_test.go
@@ -49,7 +49,7 @@ func Test_detectContentTypeAndEventID(t *testing.T) {
 func Test_transformCodePushEvent(t *testing.T) {
 	t.Log("Do Transform - single commit")
 	{
-		codePush := CodePushEventModel{
+		codePush := PushEventModel{
 			Secret:      "",
 			Ref:         "refs/heads/master",
 			CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
@@ -60,7 +60,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 				},
 			},
 		}
-		hookTransformResult := transformCodePushEvent(codePush)
+		hookTransformResult := transformPushEvent(codePush)
 		require.NoError(t, hookTransformResult.Error)
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
@@ -77,7 +77,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 
 	t.Log("Do Transform - multiple commits - CheckoutSHA match should trigger the build")
 	{
-		codePush := CodePushEventModel{
+		codePush := PushEventModel{
 			Secret:      "",
 			Ref:         "refs/heads/master",
 			CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
@@ -96,7 +96,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 				},
 			},
 		}
-		hookTransformResult := transformCodePushEvent(codePush)
+		hookTransformResult := transformPushEvent(codePush)
 		require.NoError(t, hookTransformResult.Error)
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
@@ -113,7 +113,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 
 	t.Log("No commit matches CheckoutSHA")
 	{
-		codePush := CodePushEventModel{
+		codePush := PushEventModel{
 			Secret:      "",
 			Ref:         "refs/heads/master",
 			CheckoutSHA: "checkout-sha",
@@ -124,7 +124,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 				},
 			},
 		}
-		hookTransformResult := transformCodePushEvent(codePush)
+		hookTransformResult := transformPushEvent(codePush)
 		require.EqualError(t, hookTransformResult.Error, "The commit specified by 'after' was not included in the 'commits' array - no match found")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
@@ -133,7 +133,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 
 	t.Log("Not a head ref")
 	{
-		codePush := CodePushEventModel{
+		codePush := PushEventModel{
 			Secret:      "",
 			Ref:         "refs/not/head",
 			CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
@@ -144,9 +144,22 @@ func Test_transformCodePushEvent(t *testing.T) {
 				},
 			},
 		}
-		hookTransformResult := transformCodePushEvent(codePush)
-		require.True(t, hookTransformResult.ShouldSkip)
+		hookTransformResult := transformPushEvent(codePush)
 		require.EqualError(t, hookTransformResult.Error, "Ref (refs/not/head) is not a head ref")
+		require.False(t, hookTransformResult.ShouldSkip)
+		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
+	}
+
+	t.Log("Is a tag ref")
+	{
+		codePush := PushEventModel{
+			Secret:      "",
+			Ref:         "refs/tags/1.0.0",
+			CheckoutSHA: "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
+		}
+		hookTransformResult := transformPushEvent(codePush)
+		require.True(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
 		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
@@ -169,6 +182,18 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
       "message": "second commit message"
     }
   ]
+}`
+
+	const sampleTagPushData = `{
+  "secret": "",
+  "ref": "v1.12",
+  "ref_type": "tag"
+}`
+
+	const sampleBranchCreatePushData = `{
+  "secret": "",
+  "ref": "mybranch",
+  "ref_type": "branch"
 }`
 
 	t.Log("Code Push - should be handled")
@@ -195,7 +220,43 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
-	t.Log("Unsuported Content-Type")
+	t.Log("Tag Push - should be handled")
+	{
+		request := http.Request{
+			Header: http.Header{
+				"X-Gogs-Event": {"create"},
+				"Content-Type": {"application/json"},
+			},
+			Body: ioutil.NopCloser(strings.NewReader(sampleTagPushData)),
+		}
+		hookTransformResult := provider.TransformRequest(&request)
+		require.NoError(t, hookTransformResult.Error)
+		require.False(t, hookTransformResult.ShouldSkip)
+		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
+			{
+				BuildParams: bitriseapi.BuildParamsModel{
+					Tag: "v1.12",
+				},
+			},
+		}, hookTransformResult.TriggerAPIParams)
+	}
+
+	t.Log("Branch Create - should be ignored")
+	{
+		request := http.Request{
+			Header: http.Header{
+				"X-Gogs-Event": {"create"},
+				"Content-Type": {"application/json"},
+			},
+			Body: ioutil.NopCloser(strings.NewReader(sampleBranchCreatePushData)),
+		}
+		hookTransformResult := provider.TransformRequest(&request)
+		require.True(t, hookTransformResult.ShouldSkip)
+		require.EqualError(t, hookTransformResult.Error, "Ignoring branch-create request")
+		require.Nil(t, hookTransformResult.TriggerAPIParams)
+	}
+
+	t.Log("Unsupported Content-Type")
 	{
 		request := http.Request{
 			Header: http.Header{


### PR DESCRIPTION
### Notes

This PR (continues #43) addresses #30 with two changes:

Adds support for Tag triggers, which are sent as ref_type: "tag", ref: "TAGNAME".
Adds doc references to Gitea, which the GOGS handler is compatible with (since Gitea is a GOGS fork).

Includes @mac89 and @crrobinson14 's commits from #91 

We really wanted to merge the PR and we had some suggestions. Thank you guys the contribution and feel free to pick another issue as well 😺 
