### PR TITLE
Added support for pr:from_ref_updated hook on bitbucket server

### DIFF
--- a/service/hook/bitbucketserver/bitbucketserver.go
+++ b/service/hook/bitbucketserver/bitbucketserver.go
@@ -211,7 +211,7 @@ func transformPullRequestEvent(pullRequest PullRequestEventModel) hookCommon.Tra
 
 func isAcceptEventType(eventKey string) bool {
 	return (sliceutil.IsStringInSlice(eventKey,
-		[]string{"repo:refs_changed", "pr:opened", "pr:modified", "pr:merged", "diagnostics:ping"}))
+		[]string{"repo:refs_changed", "pr:opened", "pr:modified", "pr:merged", "diagnostics:ping", "pr:from_ref_updated"}))
 }
 
 // TransformRequest ...
@@ -254,7 +254,7 @@ func (hp HookProvider) TransformRequest(r *http.Request) hookCommon.TransformRes
 		return transformPushEvent(pushEvent)
 	}
 
-	if eventKey == "pr:opened" || eventKey == "pr:modified" || eventKey == "pr:merged" {
+	if eventKey == "pr:opened" || eventKey == "pr:modified" || eventKey == "pr:merged" || eventKey == "pr:from_ref_updated" {
 		var pullRequestEvent PullRequestEventModel
 		if err := json.NewDecoder(r.Body).Decode(&pullRequestEvent); err != nil {
 			return hookCommon.TransformResultModel{
@@ -264,7 +264,7 @@ func (hp HookProvider) TransformRequest(r *http.Request) hookCommon.TransformRes
 
 		return transformPullRequestEvent(pullRequestEvent)
 	}
-  
+
 	if eventKey == "diagnostics:ping" {
 		return hookCommon.TransformResultModel{
 			ShouldSkip: true,


### PR DESCRIPTION
### New Pull Request Checklist

- [X ] Run `go fmt` on your files (e.g. `go fmt ./service/common.go`, or on the whole `service` folder: `go fmt ./service/...`)
- [X ] Write tests for your code
  - The tests should cover both "success" and "error" cases.
  - The tests should also check **all the returned variables**, don't ignore any returned value!
  - Ideally the tests should be easily readable, we usually use tests to document our code instead of code comments.
    An example, if you'd write a comment like "Given X this function will return Y" or
    "Beware, if the input is X this function will return Y" then you should implement this as
    a unit test, instead of writing it as a comment.
- [X ] If your Pull Request is more than a bug fix you should also check `README.md` and change/add the descriptions there - also
  feel free to add yourself as a contributor if you implement support for a new service ;)
- [X ] Before creating the Pull Request you should also run `bitrise run test` with the [Bitrise CLI](https://www.bitrise.io/cli),
  to perform all the automatic checks (which will run on your Pull Request when you open it).


### Summary of Pull Request

This pull requests provides support for the new webhook pr:from_ref_updated that Bitbucket server is generating as of Bitbucket 7.0; big upgrade since now we can trigger builds every time that an on-going PR has new updates on the FROM branch. :)
