### PR TITLE
[PLANG-310] Set GITHUB_PR_IS_DRAFT env var for draft PRs (GitHub)

### DIFF
--- a/service/hook/github/github.go
+++ b/service/hook/github/github.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/bitrise-io/bitrise-webhooks/bitriseapi"
@@ -64,6 +65,7 @@ type PullRequestInfoModel struct {
 	Body           string          `json:"body"`
 	Merged         bool            `json:"merged"`
 	Mergeable      *bool           `json:"mergeable"`
+	Draft          bool            `json:"draft"`
 	DiffURL        string          `json:"diff_url"`
 	User           UserModel       `json:"user"`
 }
@@ -225,6 +227,13 @@ func transformPullRequestEvent(pullRequest PullRequestEventModel) hookCommon.Tra
 					PullRequestMergeBranch:   fmt.Sprintf("pull/%d/merge", pullRequest.PullRequestID),
 					PullRequestHeadBranch:    fmt.Sprintf("pull/%d/head", pullRequest.PullRequestID),
 					DiffURL:                  pullRequest.PullRequestInfo.DiffURL,
+					Environments: []bitriseapi.EnvironmentItem{
+						{
+							Name:     "GITHUB_PR_IS_DRAFT",
+							Value:    strconv.FormatBool(pullRequest.PullRequestInfo.Draft),
+							IsExpand: false,
+						},
+					},
 				},
 			},
 		},

--- a/service/hook/github/github.go
+++ b/service/hook/github/github.go
@@ -65,7 +65,7 @@ type PullRequestInfoModel struct {
 	Body           string          `json:"body"`
 	Merged         bool            `json:"merged"`
 	Mergeable      *bool           `json:"mergeable"`
-	Draft          *bool           `json:"draft"`
+	Draft          bool            `json:"draft"`
 	DiffURL        string          `json:"diff_url"`
 	User           UserModel       `json:"user"`
 }
@@ -210,10 +210,10 @@ func transformPullRequestEvent(pullRequest PullRequestEventModel) hookCommon.Tra
 	}
 
 	buildEnvs := make([]bitriseapi.EnvironmentItem, 0)
-	if pullRequest.PullRequestInfo.Draft != nil && *pullRequest.PullRequestInfo.Draft {
+	if pullRequest.PullRequestInfo.Draft {
 		buildEnvs = append(buildEnvs, bitriseapi.EnvironmentItem{
 			Name:     "GITHUB_PR_IS_DRAFT",
-			Value:    strconv.FormatBool(*pullRequest.PullRequestInfo.Draft),
+			Value:    strconv.FormatBool(pullRequest.PullRequestInfo.Draft),
 			IsExpand: false,
 		})
 	}

--- a/service/hook/github/github.go
+++ b/service/hook/github/github.go
@@ -209,6 +209,15 @@ func transformPullRequestEvent(pullRequest PullRequestEventModel) hookCommon.Tra
 		commitMsg = fmt.Sprintf("%s\n\n%s", commitMsg, pullRequest.PullRequestInfo.Body)
 	}
 
+	buildEnvs := make([]bitriseapi.EnvironmentItem, 0)
+	if pullRequest.PullRequestInfo.Draft != nil && *pullRequest.PullRequestInfo.Draft {
+		buildEnvs = append(buildEnvs, bitriseapi.EnvironmentItem{
+			Name:     "GITHUB_PR_IS_DRAFT",
+			Value:    strconv.FormatBool(*pullRequest.PullRequestInfo.Draft),
+			IsExpand: false,
+		})
+	}
+
 	return hookCommon.TransformResultModel{
 		TriggerAPIParams: []bitriseapi.TriggerAPIParamsModel{
 			{
@@ -227,13 +236,7 @@ func transformPullRequestEvent(pullRequest PullRequestEventModel) hookCommon.Tra
 					PullRequestMergeBranch:   fmt.Sprintf("pull/%d/merge", pullRequest.PullRequestID),
 					PullRequestHeadBranch:    fmt.Sprintf("pull/%d/head", pullRequest.PullRequestID),
 					DiffURL:                  pullRequest.PullRequestInfo.DiffURL,
-					Environments: []bitriseapi.EnvironmentItem{
-						{
-							Name:     "GITHUB_PR_IS_DRAFT",
-							Value:    strconv.FormatBool(*pullRequest.PullRequestInfo.Draft),
-							IsExpand: false,
-						},
-					},
+					Environments:             buildEnvs,
 				},
 			},
 		},

--- a/service/hook/github/github.go
+++ b/service/hook/github/github.go
@@ -65,7 +65,7 @@ type PullRequestInfoModel struct {
 	Body           string          `json:"body"`
 	Merged         bool            `json:"merged"`
 	Mergeable      *bool           `json:"mergeable"`
-	Draft          bool            `json:"draft"`
+	Draft          *bool           `json:"draft"`
 	DiffURL        string          `json:"diff_url"`
 	User           UserModel       `json:"user"`
 }
@@ -230,7 +230,7 @@ func transformPullRequestEvent(pullRequest PullRequestEventModel) hookCommon.Tra
 					Environments: []bitriseapi.EnvironmentItem{
 						{
 							Name:     "GITHUB_PR_IS_DRAFT",
-							Value:    strconv.FormatBool(pullRequest.PullRequestInfo.Draft),
+							Value:    strconv.FormatBool(*pullRequest.PullRequestInfo.Draft),
 							IsExpand: false,
 						},
 					},

--- a/service/hook/github/github_test.go
+++ b/service/hook/github/github_test.go
@@ -515,7 +515,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				Title:     "PR test",
 				Merged:    false,
 				Mergeable: nil,
-				Draft:     pointers.NewBoolPtr(false),
+				Draft:     false,
 				HeadBranchInfo: BranchInfoModel{
 					Ref:        "feature/github-pr",
 					CommitHash: "83b86e5f286f546dc5a4a58db66ceef44460c85e",
@@ -568,7 +568,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				Title:     "PR test",
 				Merged:    false,
 				Mergeable: pointers.NewBoolPtr(true),
-				Draft:     pointers.NewBoolPtr(false),
+				Draft:     false,
 				HeadBranchInfo: BranchInfoModel{
 					Ref:        "feature/github-pr",
 					CommitHash: "83b86e5f286f546dc5a4a58db66ceef44460c85e",
@@ -622,7 +622,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				Body:      "PR text body",
 				Merged:    false,
 				Mergeable: pointers.NewBoolPtr(true),
-				Draft:     pointers.NewBoolPtr(false),
+				Draft:     false,
 				HeadBranchInfo: BranchInfoModel{
 					Ref:        "feature/github-pr",
 					CommitHash: "83b86e5f286f546dc5a4a58db66ceef44460c85e",
@@ -676,7 +676,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				Body:      "PR text body",
 				Merged:    false,
 				Mergeable: nil,
-				Draft:     pointers.NewBoolPtr(true),
+				Draft:     true,
 				HeadBranchInfo: BranchInfoModel{
 					Ref:        "feature/github-pr",
 					CommitHash: "83b86e5f286f546dc5a4a58db66ceef44460c85e",
@@ -736,7 +736,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				Body:      "PR text body",
 				Merged:    false,
 				Mergeable: pointers.NewBoolPtr(true),
-				Draft:     pointers.NewBoolPtr(false),
+				Draft:     false,
 				HeadBranchInfo: BranchInfoModel{
 					Ref:        "feature/github-pr",
 					CommitHash: "83b86e5f286f546dc5a4a58db66ceef44460c85e",
@@ -779,7 +779,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				Body:      "PR text body",
 				Merged:    false,
 				Mergeable: pointers.NewBoolPtr(true),
-				Draft:     nil,
+				Draft:     false,
 				HeadBranchInfo: BranchInfoModel{
 					Ref:        "feature/github-pr",
 					CommitHash: "83b86e5f286f546dc5a4a58db66ceef44460c85e",
@@ -838,7 +838,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				Body:      "PR text body",
 				Merged:    false,
 				Mergeable: pointers.NewBoolPtr(true),
-				Draft:     pointers.NewBoolPtr(false),
+				Draft:     false,
 				HeadBranchInfo: BranchInfoModel{
 					Ref:        "feature/github-pr",
 					CommitHash: "83b86e5f286f546dc5a4a58db66ceef44460c85e",
@@ -881,7 +881,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				Body:      "PR text body",
 				Merged:    false,
 				Mergeable: pointers.NewBoolPtr(true),
-				Draft:     pointers.NewBoolPtr(false),
+				Draft:     false,
 				HeadBranchInfo: BranchInfoModel{
 					Ref:        "feature/github-pr",
 					CommitHash: "83b86e5f286f546dc5a4a58db66ceef44460c85e",

--- a/service/hook/github/github_test.go
+++ b/service/hook/github/github_test.go
@@ -552,13 +552,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 					HeadRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
 					PullRequestMergeBranch:   "pull/12/merge",
 					PullRequestHeadBranch:    "pull/12/head",
-					Environments: []bitriseapi.EnvironmentItem{
-						{
-							Name:     "GITHUB_PR_IS_DRAFT",
-							Value:    "false",
-							IsExpand: false,
-						},
-					},
+					Environments:             make([]bitriseapi.EnvironmentItem, 0),
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
@@ -611,13 +605,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 					HeadRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
 					PullRequestMergeBranch:   "pull/12/merge",
 					PullRequestHeadBranch:    "pull/12/head",
-					Environments: []bitriseapi.EnvironmentItem{
-						{
-							Name:     "GITHUB_PR_IS_DRAFT",
-							Value:    "false",
-							IsExpand: false,
-						},
-					},
+					Environments:             make([]bitriseapi.EnvironmentItem, 0),
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
@@ -671,13 +659,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 					HeadRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
 					PullRequestMergeBranch:   "pull/12/merge",
 					PullRequestHeadBranch:    "pull/12/head",
-					Environments: []bitriseapi.EnvironmentItem{
-						{
-							Name:     "GITHUB_PR_IS_DRAFT",
-							Value:    "false",
-							IsExpand: false,
-						},
-					},
+					Environments:             make([]bitriseapi.EnvironmentItem, 0),
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
@@ -797,7 +779,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				Body:      "PR text body",
 				Merged:    false,
 				Mergeable: pointers.NewBoolPtr(true),
-				Draft:     pointers.NewBoolPtr(false),
+				Draft:     nil,
 				HeadBranchInfo: BranchInfoModel{
 					Ref:        "feature/github-pr",
 					CommitHash: "83b86e5f286f546dc5a4a58db66ceef44460c85e",
@@ -839,13 +821,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 					HeadRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
 					PullRequestMergeBranch:   "pull/12/merge",
 					PullRequestHeadBranch:    "pull/12/head",
-					Environments: []bitriseapi.EnvironmentItem{
-						{
-							Name:     "GITHUB_PR_IS_DRAFT",
-							Value:    "false",
-							IsExpand: false,
-						},
-					},
+					Environments:             make([]bitriseapi.EnvironmentItem, 0),
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
@@ -947,13 +923,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 					HeadRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
 					PullRequestMergeBranch:   "pull/12/merge",
 					PullRequestHeadBranch:    "pull/12/head",
-					Environments: []bitriseapi.EnvironmentItem{
-						{
-							Name:     "GITHUB_PR_IS_DRAFT",
-							Value:    "false",
-							IsExpand: false,
-						},
-					},
+					Environments:             make([]bitriseapi.EnvironmentItem, 0),
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
@@ -1155,13 +1125,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 					PullRequestAuthor:        "Author Name",
 					PullRequestMergeBranch:   "pull/12/merge",
 					PullRequestHeadBranch:    "pull/12/head",
-					Environments: []bitriseapi.EnvironmentItem{
-						{
-							Name:     "GITHUB_PR_IS_DRAFT",
-							Value:    "false",
-							IsExpand: false,
-						},
-					},
+					Environments:             make([]bitriseapi.EnvironmentItem, 0),
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)
@@ -1235,13 +1199,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 					HeadRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
 					PullRequestMergeBranch:   "pull/12/merge",
 					PullRequestHeadBranch:    "pull/12/head",
-					Environments: []bitriseapi.EnvironmentItem{
-						{
-							Name:     "GITHUB_PR_IS_DRAFT",
-							Value:    "false",
-							IsExpand: false,
-						},
-					},
+					Environments:             make([]bitriseapi.EnvironmentItem, 0),
 				},
 			},
 		}, hookTransformResult.TriggerAPIParams)

--- a/service/hook/github/github_test.go
+++ b/service/hook/github/github_test.go
@@ -515,7 +515,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				Title:     "PR test",
 				Merged:    false,
 				Mergeable: nil,
-				Draft:     false,
+				Draft:     pointers.NewBoolPtr(false),
 				HeadBranchInfo: BranchInfoModel{
 					Ref:        "feature/github-pr",
 					CommitHash: "83b86e5f286f546dc5a4a58db66ceef44460c85e",
@@ -574,7 +574,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				Title:     "PR test",
 				Merged:    false,
 				Mergeable: pointers.NewBoolPtr(true),
-				Draft:     false,
+				Draft:     pointers.NewBoolPtr(false),
 				HeadBranchInfo: BranchInfoModel{
 					Ref:        "feature/github-pr",
 					CommitHash: "83b86e5f286f546dc5a4a58db66ceef44460c85e",
@@ -634,7 +634,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				Body:      "PR text body",
 				Merged:    false,
 				Mergeable: pointers.NewBoolPtr(true),
-				Draft:     false,
+				Draft:     pointers.NewBoolPtr(false),
 				HeadBranchInfo: BranchInfoModel{
 					Ref:        "feature/github-pr",
 					CommitHash: "83b86e5f286f546dc5a4a58db66ceef44460c85e",
@@ -694,7 +694,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				Body:      "PR text body",
 				Merged:    false,
 				Mergeable: nil,
-				Draft:     true,
+				Draft:     pointers.NewBoolPtr(true),
 				HeadBranchInfo: BranchInfoModel{
 					Ref:        "feature/github-pr",
 					CommitHash: "83b86e5f286f546dc5a4a58db66ceef44460c85e",
@@ -754,7 +754,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				Body:      "PR text body",
 				Merged:    false,
 				Mergeable: pointers.NewBoolPtr(true),
-				Draft:     false,
+				Draft:     pointers.NewBoolPtr(false),
 				HeadBranchInfo: BranchInfoModel{
 					Ref:        "feature/github-pr",
 					CommitHash: "83b86e5f286f546dc5a4a58db66ceef44460c85e",
@@ -797,7 +797,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				Body:      "PR text body",
 				Merged:    false,
 				Mergeable: pointers.NewBoolPtr(true),
-				Draft:     false,
+				Draft:     pointers.NewBoolPtr(false),
 				HeadBranchInfo: BranchInfoModel{
 					Ref:        "feature/github-pr",
 					CommitHash: "83b86e5f286f546dc5a4a58db66ceef44460c85e",
@@ -862,7 +862,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				Body:      "PR text body",
 				Merged:    false,
 				Mergeable: pointers.NewBoolPtr(true),
-				Draft:     false,
+				Draft:     pointers.NewBoolPtr(false),
 				HeadBranchInfo: BranchInfoModel{
 					Ref:        "feature/github-pr",
 					CommitHash: "83b86e5f286f546dc5a4a58db66ceef44460c85e",
@@ -905,7 +905,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 				Body:      "PR text body",
 				Merged:    false,
 				Mergeable: pointers.NewBoolPtr(true),
-				Draft:     false,
+				Draft:     pointers.NewBoolPtr(false),
 				HeadBranchInfo: BranchInfoModel{
 					Ref:        "feature/github-pr",
 					CommitHash: "83b86e5f286f546dc5a4a58db66ceef44460c85e",
@@ -1081,7 +1081,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 					CommitMessage: "re-structuring Hook Providers, with added tests",
 					Branch:        "master",
 					PushCommitPaths: []bitriseapi.CommitPaths{
-						bitriseapi.CommitPaths{
+						{
 							Added:    []string{"added/file/path"},
 							Removed:  []string{"removed/file/path"},
 							Modified: []string{"modified/file/path"},
@@ -1113,7 +1113,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 					CommitHash:    "2e197ebd2330183ae11338151cf3a75db0c23c92",
 					CommitMessage: "generalize Push Event (previously Code Push)\n\nwe'll handle the Tag Push too, so related codes are changed to reflect this (removed code from CodePush - e.g. CodePushEventModel -> PushEventModel)",
 					PushCommitPaths: []bitriseapi.CommitPaths{
-						bitriseapi.CommitPaths{
+						{
 							Added:    []string{"added/file/path"},
 							Removed:  []string{"removed/file/path"},
 							Modified: []string{"modified/file/path"},


### PR DESCRIPTION
### Small summary

Check the draft state of the PR and set the GITHUB_PR_IS_DRAFT in the CI. Customers can check the env. var. value and can create a custom abort logic on it. 
This is the early stage of the draft aborting feature.
