### PR TITLE
[GitHub] Add support for ready_for_review github trigger

### DIFF
--- a/service/hook/github/github.go
+++ b/service/hook/github/github.go
@@ -179,7 +179,7 @@ func transformPushEvent(pushEvent PushEventModel) hookCommon.TransformResultMode
 }
 
 func isAcceptPullRequestAction(prAction string) bool {
-	return sliceutil.IsStringInSlice(prAction, []string{"opened", "reopened", "synchronize", "edited"})
+	return sliceutil.IsStringInSlice(prAction, []string{"opened", "reopened", "synchronize", "edited", "ready_for_review"})
 }
 
 func transformPullRequestEvent(pullRequest PullRequestEventModel) hookCommon.TransformResultModel {

--- a/service/hook/github/github_test.go
+++ b/service/hook/github/github_test.go
@@ -1010,7 +1010,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 func Test_isAcceptPullRequestAction(t *testing.T) {
 	t.Log("Accept")
 	{
-		for _, anAction := range []string{"opened", "reopened", "synchronize", "edited"} {
+		for _, anAction := range []string{"opened", "reopened", "synchronize", "edited", "ready_for_review"} {
 			t.Log(" * " + anAction)
 			require.Equal(t, true, isAcceptPullRequestAction(anAction))
 		}


### PR DESCRIPTION
### New Pull Request Checklist

- [x] Run `go fmt` on your files (e.g. `go fmt ./service/common.go`, or on the whole `service` folder: `go fmt ./service/...`)
- [x] Write tests for your code
  - The tests should cover both "success" and "error" cases.
  - The tests should also check **all the returned variables**, don't ignore any returned value!
  - Ideally the tests should be easily readable, we usually use tests to document our code instead of code comments.
    An example, if you'd write a comment like "Given X this function will return Y" or
    "Beware, if the input is X this function will return Y" then you should implement this as
    a unit test, instead of writing it as a comment.
- [x] If your Pull Request is more than a bug fix you should also check `README.md` and change/add the descriptions there - also
  feel free to add yourself as a contributor if you implement support for a new service ;)
- [x] Before creating the Pull Request you should also run `bitrise run test` with the [Bitrise CLI](https://www.bitrise.io/cli),
  to perform all the automatic checks (which will run on your Pull Request when you open it).


### Summary of Pull Request

This Pull Request adds support for an extra [Github Pull Request trigger](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), the `ready_for_review`.

#### Explanation
This assists when using `GITHUB_PR_IS_DRAFT` environment variable to early-exit a build.
When that PR gets marked as `Ready for Review` there wasn't any other way other than a commit to the branch to trigger a new build on that PR.