### PR TITLE
Revert "Add support for ready_for_review github trigger (#118)"

### DIFF
--- a/service/hook/github/github.go
+++ b/service/hook/github/github.go
@@ -179,7 +179,7 @@ func transformPushEvent(pushEvent PushEventModel) hookCommon.TransformResultMode
 }
 
 func isAcceptPullRequestAction(prAction string) bool {
-	return sliceutil.IsStringInSlice(prAction, []string{"opened", "reopened", "synchronize", "edited", "ready_for_review"})
+	return sliceutil.IsStringInSlice(prAction, []string{"opened", "reopened", "synchronize", "edited"})
 }
 
 func transformPullRequestEvent(pullRequest PullRequestEventModel) hookCommon.TransformResultModel {

--- a/service/hook/github/github_test.go
+++ b/service/hook/github/github_test.go
@@ -1010,7 +1010,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 func Test_isAcceptPullRequestAction(t *testing.T) {
 	t.Log("Accept")
 	{
-		for _, anAction := range []string{"opened", "reopened", "synchronize", "edited", "ready_for_review"} {
+		for _, anAction := range []string{"opened", "reopened", "synchronize", "edited"} {
 			t.Log(" * " + anAction)
 			require.Equal(t, true, isAcceptPullRequestAction(anAction))
 		}


### PR DESCRIPTION
This reverts commit 84975a4290e457f7ee82238f16c8990bc80a2a35.

### New Pull Request Checklist

- [x] Run `go fmt` on your files (e.g. `go fmt ./service/common.go`, or on the whole `service` folder: `go fmt ./service/...`)
- [x] Write tests for your code
  - The tests should cover both "success" and "error" cases.
  - The tests should also check **all the returned variables**, don't ignore any returned value!
  - Ideally the tests should be easily readable, we usually use tests to document our code instead of code comments.
    An example, if you'd write a comment like "Given X this function will return Y" or
    "Beware, if the input is X this function will return Y" then you should implement this as
    a unit test, instead of writing it as a comment.
- [x] If your Pull Request is more than a bug fix you should also check `README.md` and change/add the descriptions there - also
  feel free to add yourself as a contributor if you implement support for a new service ;)
- [x] Before creating the Pull Request you should also run `bitrise run test` with the [Bitrise CLI](https://www.bitrise.io/cli),
  to perform all the automatic checks (which will run on your Pull Request when you open it).

### Summary of Pull Request

This Pull Request reverts #118 . We started to get reports from customers that they didn’t expect that their builds start when the PR changes its ready to review status.

So far it seems there are cases when this is not the desired behaviour, therefore we have to remove this feature until we can make it configurable, so everybody could use it as they prefer.

As this change may affect multiple parts of the product we are not sure yet when could we add the feature again.

FYI @cmargonis, sorry for the inconvenience.