### PR TITLE
Forward unverified merge ref in a new field

### DIFF
--- a/bitriseapi/bitriseapi.go
+++ b/bitriseapi/bitriseapi.go
@@ -55,8 +55,14 @@ type BuildParamsModel struct {
 	BaseRepositoryURL string `json:"base_repository_url,omitempty"`
 	// URL of the head repository
 	HeadRepositoryURL string `json:"head_repository_url,omitempty"`
-	// pre-merged branch if the provider supports it, exposed for pull requests
+	// Pre-merged PR state, created by the git provider (if supported).
+	// IMPORTANT: This should only be defined if the state is already up-to-date with the latest PR head state
+	// Otherwise, use PullRequestUnverifiedMergeBranch.
 	PullRequestMergeBranch string `json:"pull_request_merge_branch,omitempty"`
+	// Similar to PullRequestMergeBranch, but this field contains a potentially stale state. One example is when a
+	// PR branch gets a new commit and the merge ref is not updated yet.
+	// A system using this field should check the freshness of the merge ref by other means before using it for checkouts.
+	PullRequestUnverifiedMergeBranch string `json:"pull_request_unverified_merge_branch,omitempty"`
 	// source branch mapped to the original repository if the provider supports it, exposed for pull requests
 	PullRequestHeadBranch string `json:"pull_request_head_branch,omitempty"`
 	// The creator of the pull request

--- a/service/hook/github/github.go
+++ b/service/hook/github/github.go
@@ -112,7 +112,7 @@ type HookProvider struct{}
 func transformPushEvent(pushEvent PushEventModel) hookCommon.TransformResultModel {
 	if pushEvent.Deleted {
 		return hookCommon.TransformResultModel{
-			Error: errors.New("This is a 'Deleted' event, no build can be started"),
+			Error: errors.New("this is a 'Deleted' event, no build can be started"),
 			// ShouldSkip because there's no reason to respond with a "red" / 4xx error for this event,
 			// but this event should never start a build either, so we mark this with `ShouldSkip`
 			// to return with the error message (above), but with a "green" / 2xx http code.
@@ -128,7 +128,7 @@ func transformPushEvent(pushEvent PushEventModel) hookCommon.TransformResultMode
 
 		if len(headCommit.CommitHash) == 0 {
 			return hookCommon.TransformResultModel{
-				Error: fmt.Errorf("Missing commit hash"),
+				Error: fmt.Errorf("missing commit hash"),
 			}
 		}
 
@@ -152,7 +152,7 @@ func transformPushEvent(pushEvent PushEventModel) hookCommon.TransformResultMode
 
 		if len(headCommit.CommitHash) == 0 {
 			return hookCommon.TransformResultModel{
-				Error: fmt.Errorf("Missing commit hash"),
+				Error: fmt.Errorf("missing commit hash"),
 			}
 		}
 
@@ -173,7 +173,7 @@ func transformPushEvent(pushEvent PushEventModel) hookCommon.TransformResultMode
 	}
 
 	return hookCommon.TransformResultModel{
-		Error:      fmt.Errorf("Ref (%s) is not a head nor a tag ref", pushEvent.Ref),
+		Error:      fmt.Errorf("ref (%s) is not a head nor a tag ref", pushEvent.Ref),
 		ShouldSkip: true,
 	}
 }
@@ -185,13 +185,13 @@ func isAcceptPullRequestAction(prAction string) bool {
 func transformPullRequestEvent(pullRequest PullRequestEventModel) hookCommon.TransformResultModel {
 	if pullRequest.Action == "" {
 		return hookCommon.TransformResultModel{
-			Error:      errors.New("No Pull Request action specified"),
+			Error:      errors.New("no Pull Request action specified"),
 			ShouldSkip: true,
 		}
 	}
 	if !isAcceptPullRequestAction(pullRequest.Action) {
 		return hookCommon.TransformResultModel{
-			Error:      fmt.Errorf("Pull Request action doesn't require a build: %s", pullRequest.Action),
+			Error:      fmt.Errorf("pull Request action doesn't require a build: %s", pullRequest.Action),
 			ShouldSkip: true,
 		}
 	}
@@ -200,7 +200,7 @@ func transformPullRequestEvent(pullRequest PullRequestEventModel) hookCommon.Tra
 		if pullRequest.Changes.Base == nil {
 			if !hookCommon.IsSkipBuildByCommitMessage(pullRequest.Changes.Title.From) && !hookCommon.IsSkipBuildByCommitMessage(pullRequest.Changes.Body.From) {
 				return hookCommon.TransformResultModel{
-					Error:      errors.New("Pull Request edit doesn't require a build: only title and/or description was changed, and previous one was not skipped"),
+					Error:      errors.New("pull Request edit doesn't require a build: only title and/or description was changed, and previous one was not skipped"),
 					ShouldSkip: true,
 				}
 			}
@@ -208,21 +208,22 @@ func transformPullRequestEvent(pullRequest PullRequestEventModel) hookCommon.Tra
 	}
 	if pullRequest.PullRequestInfo.Merged {
 		return hookCommon.TransformResultModel{
-			Error:      errors.New("Pull Request already merged"),
+			Error:      errors.New("pull Request already merged"),
 			ShouldSkip: true,
 		}
 	}
-	
-	// If `mergeable` is nil, the merge ref is not up to date, it's not safe to use for checkouts.
-	// Later we should trigger a refresh of the merge ref
+
+	headRefBuildParam := fmt.Sprintf("pull/%d/head", pullRequest.PullRequestID)
+	unverifiedMergeRefBuildParam := fmt.Sprintf("pull/%d/merge", pullRequest.PullRequestID)
+	// If `mergeable` is nil, the merge ref is not up-to-date, it's not safe to use for checkouts.
 	mergeRefUpToDate := pullRequest.PullRequestInfo.Mergeable != nil
 	var mergeRefBuildParam string
 	if mergeRefUpToDate {
-		mergeRefBuildParam = fmt.Sprintf("pull/%d/merge", pullRequest.PullRequestID)
+		mergeRefBuildParam = unverifiedMergeRefBuildParam
 	}
 	if mergeRefUpToDate && *pullRequest.PullRequestInfo.Mergeable == false {
 		return hookCommon.TransformResultModel{
-			Error:      errors.New("Pull Request is not mergeable"),
+			Error:      errors.New("pull Request is not mergeable"),
 			ShouldSkip: true,
 		}
 	}
@@ -245,21 +246,22 @@ func transformPullRequestEvent(pullRequest PullRequestEventModel) hookCommon.Tra
 		TriggerAPIParams: []bitriseapi.TriggerAPIParamsModel{
 			{
 				BuildParams: bitriseapi.BuildParamsModel{
-					CommitMessage:            commitMsg,
-					CommitHash:               pullRequest.PullRequestInfo.HeadBranchInfo.CommitHash,
-					Branch:                   pullRequest.PullRequestInfo.HeadBranchInfo.Ref,
-					BranchRepoOwner:          pullRequest.PullRequestInfo.HeadBranchInfo.Repo.Owner.Login,
-					BranchDest:               pullRequest.PullRequestInfo.BaseBranchInfo.Ref,
-					BranchDestRepoOwner:      pullRequest.PullRequestInfo.BaseBranchInfo.Repo.Owner.Login,
-					PullRequestID:            &pullRequest.PullRequestID,
-					BaseRepositoryURL:        pullRequest.PullRequestInfo.BaseBranchInfo.getRepositoryURL(),
-					HeadRepositoryURL:        pullRequest.PullRequestInfo.HeadBranchInfo.getRepositoryURL(),
-					PullRequestRepositoryURL: pullRequest.PullRequestInfo.HeadBranchInfo.getRepositoryURL(),
-					PullRequestAuthor:        pullRequest.PullRequestInfo.User.Login,
-					PullRequestMergeBranch:   mergeRefBuildParam,
-					PullRequestHeadBranch:    fmt.Sprintf("pull/%d/head", pullRequest.PullRequestID),
-					DiffURL:                  pullRequest.PullRequestInfo.DiffURL,
-					Environments:             buildEnvs,
+					CommitMessage:                    commitMsg,
+					CommitHash:                       pullRequest.PullRequestInfo.HeadBranchInfo.CommitHash,
+					Branch:                           pullRequest.PullRequestInfo.HeadBranchInfo.Ref,
+					BranchRepoOwner:                  pullRequest.PullRequestInfo.HeadBranchInfo.Repo.Owner.Login,
+					BranchDest:                       pullRequest.PullRequestInfo.BaseBranchInfo.Ref,
+					BranchDestRepoOwner:              pullRequest.PullRequestInfo.BaseBranchInfo.Repo.Owner.Login,
+					PullRequestID:                    &pullRequest.PullRequestID,
+					BaseRepositoryURL:                pullRequest.PullRequestInfo.BaseBranchInfo.getRepositoryURL(),
+					HeadRepositoryURL:                pullRequest.PullRequestInfo.HeadBranchInfo.getRepositoryURL(),
+					PullRequestRepositoryURL:         pullRequest.PullRequestInfo.HeadBranchInfo.getRepositoryURL(),
+					PullRequestAuthor:                pullRequest.PullRequestInfo.User.Login,
+					PullRequestHeadBranch:            headRefBuildParam,
+					PullRequestMergeBranch:           mergeRefBuildParam,
+					PullRequestUnverifiedMergeBranch: unverifiedMergeRefBuildParam,
+					DiffURL:                          pullRequest.PullRequestInfo.DiffURL,
+					Environments:                     buildEnvs,
 				},
 				TriggeredBy: hookCommon.GenerateTriggeredBy(ProviderID, pullRequest.Sender.Login),
 			},
@@ -300,20 +302,20 @@ func (hp HookProvider) TransformRequest(r *http.Request) hookCommon.TransformRes
 
 	if ghEvent == "ping" {
 		return hookCommon.TransformResultModel{
-			Error:      fmt.Errorf("Ping event received"),
+			Error:      fmt.Errorf("ping event received"),
 			ShouldSkip: true,
 		}
 	}
 	if ghEvent != "push" && ghEvent != "pull_request" {
 		// Unsupported GitHub Event
 		return hookCommon.TransformResultModel{
-			Error: fmt.Errorf("Unsupported GitHub Webhook event: %s", ghEvent),
+			Error: fmt.Errorf("unsupported GitHub Webhook event: %s", ghEvent),
 		}
 	}
 
 	if r.Body == nil {
 		return hookCommon.TransformResultModel{
-			Error: fmt.Errorf("Failed to read content of request body: no or empty request body"),
+			Error: fmt.Errorf("failed to read content of request body: no or empty request body"),
 		}
 	}
 
@@ -327,7 +329,7 @@ func (hp HookProvider) TransformRequest(r *http.Request) hookCommon.TransformRes
 		} else if contentType == hookCommon.ContentTypeApplicationXWWWFormURLEncoded {
 			payloadValue := r.PostFormValue("payload")
 			if payloadValue == "" {
-				return hookCommon.TransformResultModel{Error: fmt.Errorf("Failed to parse request body: empty payload")}
+				return hookCommon.TransformResultModel{Error: fmt.Errorf("failed to parse request body: empty payload")}
 			}
 			if err := json.NewDecoder(strings.NewReader(payloadValue)).Decode(&pushEvent); err != nil {
 				return hookCommon.TransformResultModel{Error: fmt.Errorf("Failed to parse payload: %s", err)}
@@ -348,7 +350,7 @@ func (hp HookProvider) TransformRequest(r *http.Request) hookCommon.TransformRes
 		} else if contentType == hookCommon.ContentTypeApplicationXWWWFormURLEncoded {
 			payloadValue := r.PostFormValue("payload")
 			if payloadValue == "" {
-				return hookCommon.TransformResultModel{Error: fmt.Errorf("Failed to parse request body: empty payload")}
+				return hookCommon.TransformResultModel{Error: fmt.Errorf("failed to parse request body: empty payload")}
 			}
 			if err := json.NewDecoder(strings.NewReader(payloadValue)).Decode(&pullRequestEvent); err != nil {
 				return hookCommon.TransformResultModel{Error: fmt.Errorf("Failed to parse payload: %s", err)}

--- a/service/hook/github/github_test.go
+++ b/service/hook/github/github_test.go
@@ -418,7 +418,7 @@ func Test_transformPushEvent(t *testing.T) {
 			},
 		}
 		hookTransformResult := transformPushEvent(codePush)
-		require.EqualError(t, hookTransformResult.Error, "Missing commit hash")
+		require.EqualError(t, hookTransformResult.Error, "missing commit hash")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
 		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
@@ -437,7 +437,7 @@ func Test_transformPushEvent(t *testing.T) {
 			},
 		}
 		hookTransformResult := transformPushEvent(tagPush)
-		require.EqualError(t, hookTransformResult.Error, "Missing commit hash")
+		require.EqualError(t, hookTransformResult.Error, "missing commit hash")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
 		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
@@ -459,7 +459,7 @@ func Test_transformPushEvent(t *testing.T) {
 		}
 		hookTransformResult := transformPushEvent(codePush)
 		require.True(t, hookTransformResult.ShouldSkip)
-		require.EqualError(t, hookTransformResult.Error, "This is a 'Deleted' event, no build can be started")
+		require.EqualError(t, hookTransformResult.Error, "this is a 'Deleted' event, no build can be started")
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
 		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
@@ -480,7 +480,7 @@ func Test_transformPushEvent(t *testing.T) {
 		}
 		hookTransformResult := transformPushEvent(tagPush)
 		require.True(t, hookTransformResult.ShouldSkip)
-		require.EqualError(t, hookTransformResult.Error, "This is a 'Deleted' event, no build can be started")
+		require.EqualError(t, hookTransformResult.Error, "this is a 'Deleted' event, no build can be started")
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
 		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
@@ -500,7 +500,7 @@ func Test_transformPushEvent(t *testing.T) {
 		}
 		hookTransformResult := transformPushEvent(codePush)
 		require.True(t, hookTransformResult.ShouldSkip)
-		require.EqualError(t, hookTransformResult.Error, "Ref (refs/not/head) is not a head nor a tag ref")
+		require.EqualError(t, hookTransformResult.Error, "ref (refs/not/head) is not a head nor a tag ref")
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
 		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
 	}
@@ -514,7 +514,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 		}
 		hookTransformResult := transformPullRequestEvent(pullRequest)
 		require.True(t, hookTransformResult.ShouldSkip)
-		require.EqualError(t, hookTransformResult.Error, "Pull Request action doesn't require a build: labeled")
+		require.EqualError(t, hookTransformResult.Error, "pull Request action doesn't require a build: labeled")
 	}
 
 	t.Log("Empty Pull Request action")
@@ -522,7 +522,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 		pullRequest := PullRequestEventModel{}
 		hookTransformResult := transformPullRequestEvent(pullRequest)
 		require.True(t, hookTransformResult.ShouldSkip)
-		require.EqualError(t, hookTransformResult.Error, "No Pull Request action specified")
+		require.EqualError(t, hookTransformResult.Error, "no Pull Request action specified")
 	}
 
 	t.Log("Already Merged")
@@ -535,7 +535,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 		}
 		hookTransformResult := transformPullRequestEvent(pullRequest)
 		require.True(t, hookTransformResult.ShouldSkip)
-		require.EqualError(t, hookTransformResult.Error, "Pull Request already merged")
+		require.EqualError(t, hookTransformResult.Error, "pull Request already merged")
 	}
 
 	t.Log("Not Mergeable")
@@ -549,7 +549,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 		}
 		hookTransformResult := transformPullRequestEvent(pullRequest)
 		require.True(t, hookTransformResult.ShouldSkip)
-		require.EqualError(t, hookTransformResult.Error, "Pull Request is not mergeable")
+		require.EqualError(t, hookTransformResult.Error, "pull Request is not mergeable")
 	}
 
 	t.Log("Mergeable: not yet decided")
@@ -591,17 +591,18 @@ func Test_transformPullRequestEvent(t *testing.T) {
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
 			{
 				BuildParams: bitriseapi.BuildParamsModel{
-					CommitHash:               "83b86e5f286f546dc5a4a58db66ceef44460c85e",
-					CommitMessage:            "PR test",
-					Branch:                   "feature/github-pr",
-					BranchDest:               "master",
-					PullRequestID:            pointers.NewIntPtr(12),
-					PullRequestRepositoryURL: "https://github.com/bitrise-io/bitrise-webhooks.git",
-					BaseRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
-					HeadRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
-					PullRequestMergeBranch:   "",
-					PullRequestHeadBranch:    "pull/12/head",
-					Environments:             make([]bitriseapi.EnvironmentItem, 0),
+					CommitHash:                       "83b86e5f286f546dc5a4a58db66ceef44460c85e",
+					CommitMessage:                    "PR test",
+					Branch:                           "feature/github-pr",
+					BranchDest:                       "master",
+					PullRequestID:                    pointers.NewIntPtr(12),
+					PullRequestRepositoryURL:         "https://github.com/bitrise-io/bitrise-webhooks.git",
+					BaseRepositoryURL:                "https://github.com/bitrise-io/bitrise-webhooks.git",
+					HeadRepositoryURL:                "https://github.com/bitrise-io/bitrise-webhooks.git",
+					PullRequestMergeBranch:           "",
+					PullRequestUnverifiedMergeBranch: "pull/12/merge",
+					PullRequestHeadBranch:            "pull/12/head",
+					Environments:                     make([]bitriseapi.EnvironmentItem, 0),
 				},
 				TriggeredBy: "webhook-github/test_user",
 			},
@@ -648,17 +649,18 @@ func Test_transformPullRequestEvent(t *testing.T) {
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
 			{
 				BuildParams: bitriseapi.BuildParamsModel{
-					CommitHash:               "83b86e5f286f546dc5a4a58db66ceef44460c85e",
-					CommitMessage:            "PR test",
-					Branch:                   "feature/github-pr",
-					BranchDest:               "master",
-					PullRequestID:            pointers.NewIntPtr(12),
-					PullRequestRepositoryURL: "https://github.com/bitrise-io/bitrise-webhooks.git",
-					BaseRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
-					HeadRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
-					PullRequestMergeBranch:   "pull/12/merge",
-					PullRequestHeadBranch:    "pull/12/head",
-					Environments:             make([]bitriseapi.EnvironmentItem, 0),
+					CommitHash:                       "83b86e5f286f546dc5a4a58db66ceef44460c85e",
+					CommitMessage:                    "PR test",
+					Branch:                           "feature/github-pr",
+					BranchDest:                       "master",
+					PullRequestID:                    pointers.NewIntPtr(12),
+					PullRequestRepositoryURL:         "https://github.com/bitrise-io/bitrise-webhooks.git",
+					BaseRepositoryURL:                "https://github.com/bitrise-io/bitrise-webhooks.git",
+					HeadRepositoryURL:                "https://github.com/bitrise-io/bitrise-webhooks.git",
+					PullRequestMergeBranch:           "pull/12/merge",
+					PullRequestUnverifiedMergeBranch: "pull/12/merge",
+					PullRequestHeadBranch:            "pull/12/head",
+					Environments:                     make([]bitriseapi.EnvironmentItem, 0),
 				},
 				TriggeredBy: "webhook-github/test_user",
 			},
@@ -706,17 +708,18 @@ func Test_transformPullRequestEvent(t *testing.T) {
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
 			{
 				BuildParams: bitriseapi.BuildParamsModel{
-					CommitHash:               "83b86e5f286f546dc5a4a58db66ceef44460c85e",
-					CommitMessage:            "PR test\n\nPR text body",
-					Branch:                   "feature/github-pr",
-					BranchDest:               "master",
-					PullRequestID:            pointers.NewIntPtr(12),
-					PullRequestRepositoryURL: "https://github.com/bitrise-io/bitrise-webhooks.git",
-					BaseRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
-					HeadRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
-					PullRequestMergeBranch:   "pull/12/merge",
-					PullRequestHeadBranch:    "pull/12/head",
-					Environments:             make([]bitriseapi.EnvironmentItem, 0),
+					CommitHash:                       "83b86e5f286f546dc5a4a58db66ceef44460c85e",
+					CommitMessage:                    "PR test\n\nPR text body",
+					Branch:                           "feature/github-pr",
+					BranchDest:                       "master",
+					PullRequestID:                    pointers.NewIntPtr(12),
+					PullRequestRepositoryURL:         "https://github.com/bitrise-io/bitrise-webhooks.git",
+					BaseRepositoryURL:                "https://github.com/bitrise-io/bitrise-webhooks.git",
+					HeadRepositoryURL:                "https://github.com/bitrise-io/bitrise-webhooks.git",
+					PullRequestMergeBranch:           "pull/12/merge",
+					PullRequestUnverifiedMergeBranch: "pull/12/merge",
+					PullRequestHeadBranch:            "pull/12/head",
+					Environments:                     make([]bitriseapi.EnvironmentItem, 0),
 				},
 				TriggeredBy: "webhook-github/test_user",
 			},
@@ -764,16 +767,17 @@ func Test_transformPullRequestEvent(t *testing.T) {
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
 			{
 				BuildParams: bitriseapi.BuildParamsModel{
-					CommitHash:               "83b86e5f286f546dc5a4a58db66ceef44460c85e",
-					CommitMessage:            "PR test\n\nPR text body",
-					Branch:                   "feature/github-pr",
-					BranchDest:               "master",
-					PullRequestID:            pointers.NewIntPtr(12),
-					PullRequestRepositoryURL: "https://github.com/bitrise-io/bitrise-webhooks.git",
-					BaseRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
-					HeadRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
-					PullRequestMergeBranch:   "",
-					PullRequestHeadBranch:    "pull/12/head",
+					CommitHash:                       "83b86e5f286f546dc5a4a58db66ceef44460c85e",
+					CommitMessage:                    "PR test\n\nPR text body",
+					Branch:                           "feature/github-pr",
+					BranchDest:                       "master",
+					PullRequestID:                    pointers.NewIntPtr(12),
+					PullRequestRepositoryURL:         "https://github.com/bitrise-io/bitrise-webhooks.git",
+					BaseRepositoryURL:                "https://github.com/bitrise-io/bitrise-webhooks.git",
+					HeadRepositoryURL:                "https://github.com/bitrise-io/bitrise-webhooks.git",
+					PullRequestMergeBranch:           "",
+					PullRequestUnverifiedMergeBranch: "pull/12/merge",
+					PullRequestHeadBranch:            "pull/12/head",
 					Environments: []bitriseapi.EnvironmentItem{
 						{
 							Name:     "GITHUB_PR_IS_DRAFT",
@@ -828,7 +832,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 			},
 		}
 		hookTransformResult := transformPullRequestEvent(pullRequest)
-		require.EqualError(t, hookTransformResult.Error, "Pull Request edit doesn't require a build: only title and/or description was changed, and previous one was not skipped")
+		require.EqualError(t, hookTransformResult.Error, "pull Request edit doesn't require a build: only title and/or description was changed, and previous one was not skipped")
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel(nil), hookTransformResult.TriggerAPIParams)
 		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
@@ -879,17 +883,18 @@ func Test_transformPullRequestEvent(t *testing.T) {
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
 			{
 				BuildParams: bitriseapi.BuildParamsModel{
-					CommitHash:               "83b86e5f286f546dc5a4a58db66ceef44460c85e",
-					CommitMessage:            "PR test\n\nPR text body",
-					Branch:                   "feature/github-pr",
-					BranchDest:               "develop",
-					PullRequestID:            pointers.NewIntPtr(12),
-					PullRequestRepositoryURL: "https://github.com/bitrise-io/bitrise-webhooks.git",
-					BaseRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
-					HeadRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
-					PullRequestMergeBranch:   "pull/12/merge",
-					PullRequestHeadBranch:    "pull/12/head",
-					Environments:             make([]bitriseapi.EnvironmentItem, 0),
+					CommitHash:                       "83b86e5f286f546dc5a4a58db66ceef44460c85e",
+					CommitMessage:                    "PR test\n\nPR text body",
+					Branch:                           "feature/github-pr",
+					BranchDest:                       "develop",
+					PullRequestID:                    pointers.NewIntPtr(12),
+					PullRequestRepositoryURL:         "https://github.com/bitrise-io/bitrise-webhooks.git",
+					BaseRepositoryURL:                "https://github.com/bitrise-io/bitrise-webhooks.git",
+					HeadRepositoryURL:                "https://github.com/bitrise-io/bitrise-webhooks.git",
+					PullRequestMergeBranch:           "pull/12/merge",
+					PullRequestUnverifiedMergeBranch: "pull/12/merge",
+					PullRequestHeadBranch:            "pull/12/head",
+					Environments:                     make([]bitriseapi.EnvironmentItem, 0),
 				},
 				TriggeredBy: "webhook-github/test_user",
 			},
@@ -937,7 +942,7 @@ func Test_transformPullRequestEvent(t *testing.T) {
 			},
 		}
 		hookTransformResult := transformPullRequestEvent(pullRequest)
-		require.EqualError(t, hookTransformResult.Error, "Pull Request edit doesn't require a build: only title and/or description was changed, and previous one was not skipped")
+		require.EqualError(t, hookTransformResult.Error, "pull Request edit doesn't require a build: only title and/or description was changed, and previous one was not skipped")
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel(nil), hookTransformResult.TriggerAPIParams)
 		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
@@ -988,17 +993,18 @@ func Test_transformPullRequestEvent(t *testing.T) {
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
 			{
 				BuildParams: bitriseapi.BuildParamsModel{
-					CommitHash:               "83b86e5f286f546dc5a4a58db66ceef44460c85e",
-					CommitMessage:            "PR test\n\nPR text body",
-					Branch:                   "feature/github-pr",
-					BranchDest:               "develop",
-					PullRequestID:            pointers.NewIntPtr(12),
-					PullRequestRepositoryURL: "https://github.com/bitrise-io/bitrise-webhooks.git",
-					BaseRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
-					HeadRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
-					PullRequestMergeBranch:   "pull/12/merge",
-					PullRequestHeadBranch:    "pull/12/head",
-					Environments:             make([]bitriseapi.EnvironmentItem, 0),
+					CommitHash:                       "83b86e5f286f546dc5a4a58db66ceef44460c85e",
+					CommitMessage:                    "PR test\n\nPR text body",
+					Branch:                           "feature/github-pr",
+					BranchDest:                       "develop",
+					PullRequestID:                    pointers.NewIntPtr(12),
+					PullRequestRepositoryURL:         "https://github.com/bitrise-io/bitrise-webhooks.git",
+					BaseRepositoryURL:                "https://github.com/bitrise-io/bitrise-webhooks.git",
+					HeadRepositoryURL:                "https://github.com/bitrise-io/bitrise-webhooks.git",
+					PullRequestMergeBranch:           "pull/12/merge",
+					PullRequestUnverifiedMergeBranch: "pull/12/merge",
+					PullRequestHeadBranch:            "pull/12/head",
+					Environments:                     make([]bitriseapi.EnvironmentItem, 0),
 				},
 				TriggeredBy: "webhook-github/test_user",
 			},
@@ -1040,7 +1046,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		}
 		hookTransformResult := provider.TransformRequest(&request)
 		require.True(t, hookTransformResult.ShouldSkip)
-		require.EqualError(t, hookTransformResult.Error, "Ping event received")
+		require.EqualError(t, hookTransformResult.Error, "ping event received")
 	}
 
 	t.Log("Unsuported Content-Type")
@@ -1066,7 +1072,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		}
 		hookTransformResult := provider.TransformRequest(&request)
 		require.False(t, hookTransformResult.ShouldSkip)
-		require.EqualError(t, hookTransformResult.Error, "Unsupported GitHub Webhook event: label")
+		require.EqualError(t, hookTransformResult.Error, "unsupported GitHub Webhook event: label")
 	}
 
 	t.Log("Push Event - should not be skipped")
@@ -1079,7 +1085,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		}
 		hookTransformResult := provider.TransformRequest(&request)
 		require.False(t, hookTransformResult.ShouldSkip)
-		require.EqualError(t, hookTransformResult.Error, "Failed to read content of request body: no or empty request body")
+		require.EqualError(t, hookTransformResult.Error, "failed to read content of request body: no or empty request body")
 	}
 
 	t.Log("Pull Request Event - should not be skipped")
@@ -1092,7 +1098,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		}
 		hookTransformResult := provider.TransformRequest(&request)
 		require.False(t, hookTransformResult.ShouldSkip)
-		require.EqualError(t, hookTransformResult.Error, "Failed to read content of request body: no or empty request body")
+		require.EqualError(t, hookTransformResult.Error, "failed to read content of request body: no or empty request body")
 	}
 
 	t.Log("No Request Body")
@@ -1105,7 +1111,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		}
 		hookTransformResult := provider.TransformRequest(&request)
 		require.False(t, hookTransformResult.ShouldSkip)
-		require.EqualError(t, hookTransformResult.Error, "Failed to read content of request body: no or empty request body")
+		require.EqualError(t, hookTransformResult.Error, "failed to read content of request body: no or empty request body")
 	}
 
 	t.Log("Code Push - should be handled")
@@ -1189,21 +1195,22 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
 			{
 				BuildParams: bitriseapi.BuildParamsModel{
-					DiffURL:                  "https://github.com/bitrise-io/bitrise-webhooks/pull/1.diff",
-					CommitHash:               "83b86e5f286f546dc5a4a58db66ceef44460c85e",
-					CommitMessage:            "PR test\n\nPR text body",
-					Branch:                   "feature/github-pr",
-					BranchRepoOwner:          "bitrise-team",
-					BranchDest:               "master",
-					BranchDestRepoOwner:      "bitrise-io",
-					PullRequestID:            pointers.NewIntPtr(12),
-					PullRequestRepositoryURL: "https://github.com/oss-contributor/fork-bitrise-webhooks.git",
-					BaseRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
-					HeadRepositoryURL:        "https://github.com/oss-contributor/fork-bitrise-webhooks.git",
-					PullRequestAuthor:        "Author Name",
-					PullRequestMergeBranch:   "pull/12/merge",
-					PullRequestHeadBranch:    "pull/12/head",
-					Environments:             make([]bitriseapi.EnvironmentItem, 0),
+					DiffURL:                          "https://github.com/bitrise-io/bitrise-webhooks/pull/1.diff",
+					CommitHash:                       "83b86e5f286f546dc5a4a58db66ceef44460c85e",
+					CommitMessage:                    "PR test\n\nPR text body",
+					Branch:                           "feature/github-pr",
+					BranchRepoOwner:                  "bitrise-team",
+					BranchDest:                       "master",
+					BranchDestRepoOwner:              "bitrise-io",
+					PullRequestID:                    pointers.NewIntPtr(12),
+					PullRequestRepositoryURL:         "https://github.com/oss-contributor/fork-bitrise-webhooks.git",
+					BaseRepositoryURL:                "https://github.com/bitrise-io/bitrise-webhooks.git",
+					HeadRepositoryURL:                "https://github.com/oss-contributor/fork-bitrise-webhooks.git",
+					PullRequestAuthor:                "Author Name",
+					PullRequestMergeBranch:           "pull/12/merge",
+					PullRequestUnverifiedMergeBranch: "pull/12/merge",
+					PullRequestHeadBranch:            "pull/12/head",
+					Environments:                     make([]bitriseapi.EnvironmentItem, 0),
 				},
 				TriggeredBy: "webhook-github/test_user",
 			},
@@ -1226,20 +1233,21 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
 			{
 				BuildParams: bitriseapi.BuildParamsModel{
-					DiffURL:                  "https://github.com/bitrise-io/bitrise-webhooks/pull/1.diff",
-					CommitHash:               "83b86e5f286f546dc5a4a58db66ceef44460c85e",
-					CommitMessage:            "PR test\n\nPR text body",
-					Branch:                   "feature/github-pr",
-					BranchRepoOwner:          "bitrise-team",
-					BranchDest:               "master",
-					BranchDestRepoOwner:      "bitrise-io",
-					PullRequestID:            pointers.NewIntPtr(12),
-					PullRequestRepositoryURL: "https://github.com/oss-contributor/fork-bitrise-webhooks.git",
-					BaseRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
-					HeadRepositoryURL:        "https://github.com/oss-contributor/fork-bitrise-webhooks.git",
-					PullRequestAuthor:        "Author Name",
-					PullRequestMergeBranch:   "pull/12/merge",
-					PullRequestHeadBranch:    "pull/12/head",
+					DiffURL:                          "https://github.com/bitrise-io/bitrise-webhooks/pull/1.diff",
+					CommitHash:                       "83b86e5f286f546dc5a4a58db66ceef44460c85e",
+					CommitMessage:                    "PR test\n\nPR text body",
+					Branch:                           "feature/github-pr",
+					BranchRepoOwner:                  "bitrise-team",
+					BranchDest:                       "master",
+					BranchDestRepoOwner:              "bitrise-io",
+					PullRequestID:                    pointers.NewIntPtr(12),
+					PullRequestRepositoryURL:         "https://github.com/oss-contributor/fork-bitrise-webhooks.git",
+					BaseRepositoryURL:                "https://github.com/bitrise-io/bitrise-webhooks.git",
+					HeadRepositoryURL:                "https://github.com/oss-contributor/fork-bitrise-webhooks.git",
+					PullRequestAuthor:                "Author Name",
+					PullRequestMergeBranch:           "pull/12/merge",
+					PullRequestUnverifiedMergeBranch: "pull/12/merge",
+					PullRequestHeadBranch:            "pull/12/head",
 					Environments: []bitriseapi.EnvironmentItem{
 						{
 							Name:     "GITHUB_PR_IS_DRAFT",
@@ -1269,17 +1277,18 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
 			{
 				BuildParams: bitriseapi.BuildParamsModel{
-					CommitHash:               "83b86e5f286f546dc5a4a58db66ceef44460c85e",
-					CommitMessage:            "PR test\n\nPR text body",
-					Branch:                   "feature/github-pr",
-					BranchDest:               "develop",
-					PullRequestID:            pointers.NewIntPtr(12),
-					PullRequestRepositoryURL: "https://github.com/bitrise-io/bitrise-webhooks.git",
-					BaseRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
-					HeadRepositoryURL:        "https://github.com/bitrise-io/bitrise-webhooks.git",
-					PullRequestMergeBranch:   "pull/12/merge",
-					PullRequestHeadBranch:    "pull/12/head",
-					Environments:             make([]bitriseapi.EnvironmentItem, 0),
+					CommitHash:                       "83b86e5f286f546dc5a4a58db66ceef44460c85e",
+					CommitMessage:                    "PR test\n\nPR text body",
+					Branch:                           "feature/github-pr",
+					BranchDest:                       "develop",
+					PullRequestID:                    pointers.NewIntPtr(12),
+					PullRequestRepositoryURL:         "https://github.com/bitrise-io/bitrise-webhooks.git",
+					BaseRepositoryURL:                "https://github.com/bitrise-io/bitrise-webhooks.git",
+					HeadRepositoryURL:                "https://github.com/bitrise-io/bitrise-webhooks.git",
+					PullRequestMergeBranch:           "pull/12/merge",
+					PullRequestUnverifiedMergeBranch: "pull/12/merge",
+					PullRequestHeadBranch:            "pull/12/head",
+					Environments:                     make([]bitriseapi.EnvironmentItem, 0),
 				},
 				TriggeredBy: "webhook-github/test_user",
 			},


### PR DESCRIPTION
### New Pull Request Checklist

- [ ] Run `go fmt` on your files (e.g. `go fmt ./service/common.go`, or on the whole `service` folder: `go fmt ./service/...`)
- [ ] Write tests for your code
  - The tests should cover both "success" and "error" cases.
  - The tests should also check **all the returned variables**, don't ignore any returned value!
  - Ideally the tests should be easily readable, we usually use tests to document our code instead of code comments.
    An example, if you'd write a comment like "Given X this function will return Y" or
    "Beware, if the input is X this function will return Y" then you should implement this as
    a unit test, instead of writing it as a comment.
- [ ] If your Pull Request is more than a bug fix you should also check `README.md` and change/add the descriptions there - also
  feel free to add yourself as a contributor if you implement support for a new service ;)
- [ ] Before creating the Pull Request you should also run `bitrise run test` with the [Bitrise CLI](https://www.bitrise.io/cli),
  to perform all the automatic checks (which will run on your Pull Request when you open it).


### Summary of Pull Request

Follow-up to #125 with a more permanent solution for always checking out the correct merge ref.

This PR forwards the merge ref in a new build trigger field so that the git clone step can still use it after making sure that it's up to date (or trigger an update).

I didn't touch the existing field for compatibility reasons (there are older step versions out there, we shouldn't change a field's name or meaning).