### PR TITLE
Forward GitLab merge ref only if it's up-to-date

### DIFF
--- a/service/hook/gitlab/gitlab.go
+++ b/service/hook/gitlab/gitlab.go
@@ -319,6 +319,12 @@ func transformMergeRequestEvent(mergeRequest MergeRequestEventModel) hookCommon.
 		commitMsg = fmt.Sprintf("%s\n\n%s", commitMsg, mergeRequest.ObjectAttributes.Description)
 	}
 
+	var mergeRef string
+	mergeStatus := mergeRequest.ObjectAttributes.MergeStatus
+	if mergeStatus != "preparing" && mergeStatus != "unchecked" {
+		mergeRef = fmt.Sprintf("merge-requests/%d/merge", mergeRequest.ObjectAttributes.ID)
+	}
+
 	return hookCommon.TransformResultModel{
 		DontWaitForTriggerResponse: true,
 		TriggerAPIParams: []bitriseapi.TriggerAPIParamsModel{
@@ -335,7 +341,7 @@ func transformMergeRequestEvent(mergeRequest MergeRequestEventModel) hookCommon.
 					HeadRepositoryURL:        mergeRequest.ObjectAttributes.Source.getRepositoryURL(),
 					PullRequestRepositoryURL: mergeRequest.ObjectAttributes.Source.getRepositoryURL(),
 					PullRequestAuthor:        mergeRequest.User.Name,
-					PullRequestMergeBranch:   fmt.Sprintf("merge-requests/%d/merge", mergeRequest.ObjectAttributes.ID),
+					PullRequestMergeBranch:   mergeRef,
 					PullRequestHeadBranch:    fmt.Sprintf("merge-requests/%d/head", mergeRequest.ObjectAttributes.ID),
 				},
 				TriggeredBy: hookCommon.GenerateTriggeredBy(ProviderID, mergeRequest.User.Username),

--- a/service/hook/gitlab/gitlab_test.go
+++ b/service/hook/gitlab/gitlab_test.go
@@ -74,7 +74,7 @@ const sampleForkMergeRequestData = `{
 		"target_branch": "develop",
 		"source_branch": "feature/gitlab-pr",
 		"title": "PR test",
-		"merge_status": "unchecked",
+		"merge_status": "can_be_merged",
 		"iid": 12,
 		"description": "PR text body",
 		"merge_error": null,
@@ -490,6 +490,7 @@ func Test_transformMergeRequestEvent(t *testing.T) {
 				LastCommit: LastCommitInfoModel{
 					SHA: "83b86e5f286f546dc5a4a58db66ceef44460c85e",
 				},
+				MergeStatus: "unchecked",
 			},
 		}
 
@@ -507,7 +508,7 @@ func Test_transformMergeRequestEvent(t *testing.T) {
 					BaseRepositoryURL:        "https://gitlab.com/bitrise-io/bitrise-webhooks.git",
 					HeadRepositoryURL:        "https://gitlab.com/bitrise-io/bitrise-webhooks.git",
 					PullRequestRepositoryURL: "https://gitlab.com/bitrise-io/bitrise-webhooks.git",
-					PullRequestMergeBranch:   "merge-requests/12/merge",
+					PullRequestMergeBranch:   "",
 					PullRequestHeadBranch:    "merge-requests/12/head",
 				},
 				TriggeredBy: "webhook-gitlab/test_user",
@@ -735,7 +736,7 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 					HeadRepositoryURL:        "https://gitlab.com/bitrise-io/bitrise-webhooks.git",
 					PullRequestRepositoryURL: "https://gitlab.com/bitrise-io/bitrise-webhooks.git",
 					PullRequestAuthor:        "Author Name",
-					PullRequestMergeBranch:   "merge-requests/12/merge",
+					PullRequestMergeBranch:   "",
 					PullRequestHeadBranch:    "merge-requests/12/head",
 				},
 				TriggeredBy: "webhook-gitlab/test_user",


### PR DESCRIPTION
### New Pull Request Checklist

- [ ] Run `go fmt` on your files (e.g. `go fmt ./service/common.go`, or on the whole `service` folder: `go fmt ./service/...`)
- [ ] Write tests for your code
  - The tests should cover both "success" and "error" cases.
  - The tests should also check **all the returned variables**, don't ignore any returned value!
  - Ideally the tests should be easily readable, we usually use tests to document our code instead of code comments.
    An example, if you'd write a comment like "Given X this function will return Y" or
    "Beware, if the input is X this function will return Y" then you should implement this as
    a unit test, instead of writing it as a comment.
- [ ] If your Pull Request is more than a bug fix you should also check `README.md` and change/add the descriptions there - also
  feel free to add yourself as a contributor if you implement support for a new service ;)
- [ ] Before creating the Pull Request you should also run `bitrise run test` with the [Bitrise CLI](https://www.bitrise.io/cli),
  to perform all the automatic checks (which will run on your Pull Request when you open it).


### Summary of Pull Request

Similar to https://github.com/bitrise-io/bitrise-webhooks/pull/125, which checks the merge ref in GitHub webhooks, this PR does the same for GitLab.

Note: The `merge_status` field got [deprecated recently](https://github.com/bitrise-io/bitrise-webhooks/pull/125), so we should move to the new field eventually. This is out of scope for this PR, I think we should wait a bit more for the self-hosted GitLab installations to update.
