### PR TITLE
BIVS-2257 bitbucket metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	cloud.google.com/go/pubsub v1.33.0
 	github.com/bitrise-io/api-utils v0.0.0-20211025122143-6499571b8433
+	github.com/go-playground/webhooks/v6 v6.3.0
 	github.com/google/go-github/v55 v55.0.0
 	github.com/gorilla/mux v1.8.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,11 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
+github.com/go-playground/webhooks/v6 v6.3.0 h1:zBLUxK1Scxwi97TmZt5j/B/rLlard2zY7P77FHg58FE=
+github.com/go-playground/webhooks/v6 v6.3.0/go.mod h1:GCocmfMtpJdkEOM1uG9p2nXzg1kY5X/LtvQgtPHUaaA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/gogits/go-gogs-client v0.0.0-20200905025246-8bb8a50cb355/go.mod h1:cY2AIrMgHm6oOHmR7jY+9TtjzSjQ3iG7tURJG3Y6XH0=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/service/hook/bitbucketv2/bitbucketv2.go
+++ b/service/hook/bitbucketv2/bitbucketv2.go
@@ -111,7 +111,21 @@ type PullRequestEventModel struct {
 // --- Webhook Provider Implementation ---
 
 // HookProvider ...
-type HookProvider struct{}
+type HookProvider struct {
+	timeProvider hookCommon.TimeProvider
+}
+
+// NewHookProvider ...
+func NewHookProvider(timeProvider hookCommon.TimeProvider) hookCommon.Provider {
+	return HookProvider{
+		timeProvider: timeProvider,
+	}
+}
+
+// NewDefaultHookProvider ...
+func NewDefaultHookProvider() hookCommon.Provider {
+	return NewHookProvider(hookCommon.NewDefaultTimeProvider())
+}
 
 func detectContentTypeAttemptNumberAndEventKey(header http.Header) (string, string, string, error) {
 	contentType := header.Get("Content-Type")

--- a/service/hook/bitbucketv2/metrics.go
+++ b/service/hook/bitbucketv2/metrics.go
@@ -3,6 +3,7 @@ package bitbucketv2
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/bitrise-io/bitrise-webhooks/service/hook/common"
@@ -151,14 +152,9 @@ func newPullRequestMetrics(payload interface{}, webhookType, appSlug string, cur
 func newGeneralPullRequestMetrics(pullRequest bitbucket.PullRequest) common.GeneralPullRequestMetrics {
 	prID := fmt.Sprintf("%d", pullRequest.ID)
 
-	stateMapping := map[string]string{
-		"OPEN":     "opened",
-		"MERGED":   "closed",
-		"DECLINED": "closed",
-	}
-	status, ok := stateMapping[pullRequest.State]
-	if !ok {
-		status = pullRequest.State
+	status := strings.ToLower(pullRequest.State) // OPEN, MERGED or DECLINED
+	if status == "open" {
+		status = "opened"
 	}
 
 	return common.GeneralPullRequestMetrics{

--- a/service/hook/bitbucketv2/metrics.go
+++ b/service/hook/bitbucketv2/metrics.go
@@ -137,6 +137,8 @@ func newPullRequestMetrics(payload interface{}, webhookType, appSlug string, cur
 		timestamp = &pullRequest.UpdatedOn
 		userName = payload.Actor.NickName
 		gitRef = pullRequest.Source.Branch.Name
+	default:
+		return nil
 	}
 
 	generalMetrics := common.NewGeneralMetrics(provider, repo, currentTime, timestamp, appSlug, originalTrigger, userName, gitRef)

--- a/service/hook/bitbucketv2/metrics.go
+++ b/service/hook/bitbucketv2/metrics.go
@@ -31,10 +31,6 @@ func (hp HookProvider) GatherMetrics(r *http.Request, appSlug string) ([]common.
 	if err != nil {
 		return nil, err
 	}
-	for _, metrics := range metricsList {
-		fmt.Println()
-		fmt.Print(metrics)
-	}
 
 	return metricsList, nil
 }

--- a/service/hook/bitbucketv2/metrics.go
+++ b/service/hook/bitbucketv2/metrics.go
@@ -1,0 +1,95 @@
+package bitbucketv2
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/bitrise-io/bitrise-webhooks/service/hook/common"
+	"github.com/go-playground/webhooks/v6/bitbucket"
+)
+
+// GatherMetrics ...
+func (hp HookProvider) GatherMetrics(r *http.Request, appSlug string) ([]common.Metrics, error) {
+	hook, err := bitbucket.New()
+	if err != nil {
+		return nil, err
+	}
+
+	payload, err := hook.Parse(r, bitbucket.RepoPushEvent, bitbucket.PullRequestCreatedEvent, bitbucket.PullRequestUpdatedEvent)
+	if err != nil {
+		if err == bitbucket.ErrEventNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	event := r.Header.Get("X-Event-Key")
+	currentTime := hp.timeProvider.CurrentTime()
+
+	return hp.gatherMetrics(payload, event, appSlug, currentTime), nil
+
+}
+
+func (hp HookProvider) gatherMetrics(payload interface{}, webhookType, appSlug string, currentTime time.Time) []common.Metrics {
+	switch payload := payload.(type) {
+	case bitbucket.RepoPushPayload:
+		return newPushMetrics(payload, webhookType, appSlug, currentTime)
+	case bitbucket.PullRequestCreatedPayload, bitbucket.PullRequestUpdatedPayload:
+
+	}
+
+	return nil
+}
+
+func newPushMetrics(payload bitbucket.RepoPushPayload, webhookType, appSlug string, currentTime time.Time) []common.Metrics {
+	var metricsList []common.Metrics
+
+	for _, change := range payload.Push.Changes {
+		if change.New.Target.Type == "tag" || change.Old.Target.Type == "tag" {
+			continue
+		}
+
+		var constructorFunc func(generalMetrics common.GeneralMetrics, commitIDAfter string, commitIDBefore string, oldestCommitTimestamp *time.Time, latestCommitTimestamp *time.Time, masterBranch string) common.PushMetrics
+		// general metrics
+		provider := ProviderID
+		repo := payload.Repository.FullName
+		var timestamp *time.Time
+		originalTrigger := common.OriginalTrigger(webhookType, "")
+		userName := payload.Actor.NickName
+		var gitRef string
+		// push metrics
+		commitIDAfter := change.New.Target.Hash
+		commitIDBefore := change.Old.Target.Hash
+		var oldestCommitTime *time.Time
+		var latestCommitTime *time.Time
+		var masterBranch string
+
+		isBranchCreated := change.Old.Target.Hash == ""
+		isBranchDeleted := change.New.Target.Hash == ""
+		isForcePush := change.Forced
+
+		switch {
+		case isBranchCreated:
+			constructorFunc = common.NewPushCreatedMetrics
+			timestamp = &change.New.Target.Date
+			gitRef = change.New.Name
+		case isBranchDeleted:
+			constructorFunc = common.NewPushDeletedMetrics
+			gitRef = change.Old.Name
+		case isForcePush:
+			constructorFunc = common.NewPushForcedMetrics
+			timestamp = &change.New.Target.Date
+			gitRef = change.New.Name
+		default:
+			constructorFunc = common.NewPushMetrics
+			timestamp = &change.New.Target.Date
+			gitRef = change.New.Name
+		}
+
+		generalMetrics := common.NewGeneralMetrics(provider, repo, currentTime, timestamp, appSlug, originalTrigger, userName, gitRef)
+		metrics := constructorFunc(generalMetrics, commitIDAfter, commitIDBefore, oldestCommitTime, latestCommitTime, masterBranch)
+		metricsList = append(metricsList, metrics)
+	}
+
+	return metricsList
+}

--- a/service/hook/bitbucketv2/metrics.go
+++ b/service/hook/bitbucketv2/metrics.go
@@ -28,11 +28,7 @@ func (hp HookProvider) GatherMetrics(r *http.Request, appSlug string) ([]common.
 	event := r.Header.Get("X-Event-Key")
 	currentTime := hp.timeProvider.CurrentTime()
 
-	metricsList, err := hp.gatherMetrics(payload, event, appSlug, currentTime), nil
-	if err != nil {
-		return nil, err
-	}
-
+	metricsList := hp.gatherMetrics(payload, event, appSlug, currentTime)
 	return metricsList, nil
 }
 

--- a/service/hook/bitbucketv2/metrics_test.go
+++ b/service/hook/bitbucketv2/metrics_test.go
@@ -45,7 +45,6 @@ func TestHookProvider_gatherMetrics(t *testing.T) {
 	"addition_count": 0,
 	"deletion_count": 0,
 	"commit_count": 0,
-	"merge_commit_sha": "",
 	"status": "opened"
 }
 `,
@@ -68,9 +67,6 @@ func TestHookProvider_gatherMetrics(t *testing.T) {
 	"git_ref": "dev",
 	"commit_id_after": "303f1d584a4299f6e1dabb58731ab2026ef70e05",
 	"commit_id_before": "51cdb0ee811d801a73a099b2e4f011e8d2c98efa",
-	"oldest_commit_timestamp": null,
-	"latest_commit_timestamp": null,
-	"master_branch": "",
 	"changed_files_count": 0,
 	"addition_count": 0,
 	"deletion_count": 0

--- a/service/hook/bitbucketv2/metrics_test.go
+++ b/service/hook/bitbucketv2/metrics_test.go
@@ -1,0 +1,185 @@
+package bitbucketv2
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-playground/webhooks/v6/bitbucket"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHookProvider_gatherMetrics(t *testing.T) {
+	currentTime := time.Date(2023, time.October, 26, 8, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name        string
+		event       interface{}
+		webhookType string
+		appSlug     string
+		want        string
+	}{
+		{
+			name:        "Pull Request created webhook",
+			event:       testPullRequestCreatedWebhook(t),
+			appSlug:     "slug",
+			webhookType: "pullrequest:created",
+			want: `{
+	"event": "pull_request",
+	"action": "opened",
+	"provider_type": "bitbucket-v2",
+	"repository": "bitrise-io/project",
+	"timestamp": "2023-10-26T08:00:00Z",
+	"event_timestamp": "2023-11-08T13:18:53.923474Z",
+	"app_slug": "slug",
+	"original_trigger": "pullrequest:created:",
+	"user_name": "bitrise-bot",
+	"git_ref": "dev",
+	"pull_request_title": "README.md edited online with Bitbucket",
+	"pull_request_id": "10",
+	"pull_request_url": "https://bitbucket.org/bitrise-io/project/pull-requests/10",
+	"target_branch": "master",
+	"commit_id": "66980da5d45c",
+	"changed_files_count": 0,
+	"addition_count": 0,
+	"deletion_count": 0,
+	"commit_count": 0,
+	"merge_commit_sha": "",
+	"status": "opened"
+}
+`,
+		},
+		{
+			name:        "Push webhook",
+			event:       testPushWebhook(t),
+			appSlug:     "slug",
+			webhookType: "repo:push",
+			want: `{
+	"event": "git_push",
+	"action": "forced",
+	"provider_type": "bitbucket-v2",
+	"repository": "bitrise-io/project",
+	"timestamp": "2023-10-26T08:00:00Z",
+	"event_timestamp": "2023-11-08T13:26:03Z",
+	"app_slug": "slug",
+	"original_trigger": "repo:push:",
+	"user_name": "bitrise-bot",
+	"git_ref": "dev",
+	"commit_id_after": "303f1d584a4299f6e1dabb58731ab2026ef70e05",
+	"commit_id_before": "51cdb0ee811d801a73a099b2e4f011e8d2c98efa",
+	"oldest_commit_timestamp": null,
+	"latest_commit_timestamp": null,
+	"master_branch": "",
+	"changed_files_count": 0,
+	"addition_count": 0,
+	"deletion_count": 0
+}
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hp := HookProvider{}
+			got := hp.gatherMetrics(tt.event, tt.webhookType, tt.appSlug, currentTime)
+			require.Equal(t, 1, len(got))
+			got1 := got[0]
+			gotBytes, err := got1.Serialise()
+			require.NoError(t, err)
+			require.Equal(t, compactJSON(tt.want), compactJSON(string(gotBytes)))
+		})
+	}
+}
+
+func compactJSON(s string) string {
+	s = strings.ReplaceAll(s, "\n", "")
+	s = strings.ReplaceAll(s, "\t", "")
+	s = strings.ReplaceAll(s, " ", "")
+	return s
+}
+
+func testPushWebhook(t *testing.T) interface{} {
+	var event bitbucket.RepoPushPayload
+	err := json.Unmarshal([]byte(testPushWebhookPayload), &event)
+	require.NoError(t, err)
+	return event
+}
+
+const testPushWebhookPayload = `{
+  "push": {
+    "changes": [
+      {
+        "old": {
+          "name": "dev",
+          "target": {
+            "type": "commit",
+            "hash": "51cdb0ee811d801a73a099b2e4f011e8d2c98efa",
+            "date": "2023-11-08T13:19:28+00:00"
+          },
+          "type": "branch"
+        },
+        "new": {
+          "name": "dev",
+          "target": {
+            "type": "commit",
+            "hash": "303f1d584a4299f6e1dabb58731ab2026ef70e05",
+            "date": "2023-11-08T13:26:03+00:00"
+          },
+          "type": "branch"
+        },
+        "created": false,
+        "forced": true,
+        "closed": false
+      }
+    ]
+  },
+  "repository": {
+    "full_name": "bitrise-io/project"
+  },
+  "actor": {
+    "nickname": "bitrise-bot"
+  }
+}`
+
+func testPullRequestCreatedWebhook(t *testing.T) interface{} {
+	var event bitbucket.PullRequestCreatedPayload
+	err := json.Unmarshal([]byte(testPullRequestCreatedWebhookPayload), &event)
+	require.NoError(t, err)
+	return event
+}
+
+const testPullRequestCreatedWebhookPayload = `{
+    "repository": {
+      "full_name": "bitrise-io/project"
+    },
+    "actor": {
+      "nickname": "bitrise-bot"
+    },
+    "pullrequest": {
+      "id": 10,
+      "title": "README.md edited online with Bitbucket",
+      "state": "OPEN",
+      "merge_commit": null,
+      "reason": "",
+      "created_on": "2023-11-08T13:18:53.923474+00:00",
+      "updated_on": "2023-11-08T13:18:55.372722+00:00",
+      "destination": {
+        "branch": {
+          "name": "master"
+        }
+      },
+      "source": {
+        "branch": {
+          "name": "dev"
+        },
+        "commit": {
+          "hash": "66980da5d45c"
+        }
+      },
+      "links": {
+        "html": {
+          "href": "https://bitbucket.org/bitrise-io/project/pull-requests/10"
+        }
+      }
+    }
+  }`

--- a/service/hook/common/metrics.go
+++ b/service/hook/common/metrics.go
@@ -47,7 +47,7 @@ type Metrics interface {
 
 // MetricsProvider ...
 type MetricsProvider interface {
-	GatherMetrics(r *http.Request, appSlug string) (Metrics, error)
+	GatherMetrics(r *http.Request, appSlug string) ([]Metrics, error)
 }
 
 // OriginalTrigger ...

--- a/service/hook/endpoint.go
+++ b/service/hook/endpoint.go
@@ -179,7 +179,7 @@ func (c *Client) HTTPHandler(w http.ResponseWriter, r *http.Request) {
 
 	metricsProvider, isMetricsProvider := hookProvider.(hookCommon.MetricsProvider)
 	if c.PubsubClient != nil && isMetricsProvider {
-		var webhookMetrics hookCommon.Metrics
+		var webhookMetricsList []hookCommon.Metrics
 		var err error
 
 		metrics.Trace("Hook: GatherMetrics", func() {
@@ -198,7 +198,7 @@ func (c *Client) HTTPHandler(w http.ResponseWriter, r *http.Request) {
 				r.Body = io.NopCloser(bytes.NewBuffer(originalBody))
 			}
 
-			webhookMetrics, err = metricsProvider.GatherMetrics(r, appSlug)
+			webhookMetricsList, err = metricsProvider.GatherMetrics(r, appSlug)
 
 			if originalBody != nil {
 				r.Body = io.NopCloser(bytes.NewBuffer(originalBody))
@@ -209,9 +209,11 @@ func (c *Client) HTTPHandler(w http.ResponseWriter, r *http.Request) {
 			logger.Error("Failed to gather metrics from the webhook", zap.Error(err))
 		}
 
-		if webhookMetrics != nil {
-			if err := c.PubsubClient.PublishMetrics(reqContext, webhookMetrics); err != nil {
-				logger.Error(" [!] Exception: PublishMetrics: failed to publish metrics results", zap.Error(err))
+		if len(webhookMetricsList) > 0 {
+			for _, webhookMetrics := range webhookMetricsList {
+				if err := c.PubsubClient.PublishMetrics(reqContext, webhookMetrics); err != nil {
+					logger.Error(" [!] Exception: PublishMetrics: failed to publish metrics results", zap.Error(err))
+				}
 			}
 		}
 	}

--- a/service/hook/endpoint.go
+++ b/service/hook/endpoint.go
@@ -39,7 +39,7 @@ type Client struct {
 func supportedProviders() map[string]hookCommon.Provider {
 	return map[string]hookCommon.Provider{
 		github.ProviderID:                   github.NewDefaultHookProvider(),
-		bitbucketv2.ProviderID:              bitbucketv2.HookProvider{},
+		bitbucketv2.ProviderID:              bitbucketv2.NewDefaultHookProvider(),
 		bitbucketserver.ProviderID:          bitbucketserver.HookProvider{},
 		slack.ProviderID:                    slack.HookProvider{},
 		visualstudioteamservices.ProviderID: visualstudioteamservices.HookProvider{},

--- a/service/hook/github/metrics.go
+++ b/service/hook/github/metrics.go
@@ -25,6 +25,9 @@ func (hp HookProvider) GatherMetrics(r *http.Request, appSlug string) ([]common.
 
 	currentTime := hp.timeProvider.CurrentTime()
 	metrics := hp.gatherMetrics(event, webhookType, appSlug, currentTime)
+	if metrics == nil {
+		return nil, nil
+	}
 	return []common.Metrics{metrics}, nil
 }
 

--- a/service/hook/github/metrics.go
+++ b/service/hook/github/metrics.go
@@ -237,7 +237,7 @@ func newPullRequestCommentMetrics(event interface{}, webhookType, appSlug string
 
 func newGeneralPullRequestMetrics(pullRequest *github.PullRequest, mergeCommitSHA string) common.GeneralPullRequestMetrics {
 	prID := fmt.Sprintf("%d", pullRequest.GetNumber())
-	status := pullRequest.GetState()
+	status := pullRequest.GetState() // open or closed
 	if status == "open" {
 		status = "opened"
 	}

--- a/service/hook/github/metrics.go
+++ b/service/hook/github/metrics.go
@@ -24,14 +24,11 @@ func (hp HookProvider) GatherMetrics(r *http.Request, appSlug string) ([]common.
 	}
 
 	currentTime := hp.timeProvider.CurrentTime()
-	metrics := hp.gatherMetrics(event, webhookType, appSlug, currentTime)
-	if metrics == nil {
-		return nil, nil
-	}
-	return []common.Metrics{metrics}, nil
+	metricsList := hp.gatherMetrics(event, webhookType, appSlug, currentTime)
+	return metricsList, nil
 }
 
-func (hp HookProvider) gatherMetrics(event interface{}, webhookType, appSlug string, currentTime time.Time) common.Metrics {
+func (hp HookProvider) gatherMetrics(event interface{}, webhookType, appSlug string, currentTime time.Time) []common.Metrics {
 	var metrics common.Metrics
 	switch event := event.(type) {
 	case *github.PushEvent, *github.DeleteEvent, *github.CreateEvent:
@@ -42,7 +39,11 @@ func (hp HookProvider) gatherMetrics(event interface{}, webhookType, appSlug str
 		metrics = newPullRequestCommentMetrics(event, webhookType, appSlug, currentTime)
 	}
 
-	return metrics
+	if metrics == nil {
+		return nil
+	}
+
+	return []common.Metrics{metrics}
 }
 
 func newPushMetrics(event interface{}, webhookType, appSlug string, currentTime time.Time) *common.PushMetrics {

--- a/service/hook/github/metrics.go
+++ b/service/hook/github/metrics.go
@@ -24,11 +24,7 @@ func (hp HookProvider) GatherMetrics(r *http.Request, appSlug string) ([]common.
 	}
 
 	currentTime := hp.timeProvider.CurrentTime()
-	metrics, err := hp.gatherMetrics(event, webhookType, appSlug, currentTime), nil
-	if err != nil {
-		return nil, err
-	}
-
+	metrics := hp.gatherMetrics(event, webhookType, appSlug, currentTime)
 	return []common.Metrics{metrics}, nil
 }
 

--- a/service/hook/github/metrics.go
+++ b/service/hook/github/metrics.go
@@ -10,7 +10,7 @@ import (
 )
 
 // GatherMetrics ...
-func (hp HookProvider) GatherMetrics(r *http.Request, appSlug string) (common.Metrics, error) {
+func (hp HookProvider) GatherMetrics(r *http.Request, appSlug string) ([]common.Metrics, error) {
 	payload, err := github.ValidatePayload(r, nil)
 	if err != nil {
 		return nil, err
@@ -24,7 +24,12 @@ func (hp HookProvider) GatherMetrics(r *http.Request, appSlug string) (common.Me
 	}
 
 	currentTime := hp.timeProvider.CurrentTime()
-	return hp.gatherMetrics(event, webhookType, appSlug, currentTime), nil
+	metrics, err := hp.gatherMetrics(event, webhookType, appSlug, currentTime), nil
+	if err != nil {
+		return nil, err
+	}
+
+	return []common.Metrics{metrics}, nil
 }
 
 func (hp HookProvider) gatherMetrics(event interface{}, webhookType, appSlug string, currentTime time.Time) common.Metrics {

--- a/service/hook/gitlab/metrics.go
+++ b/service/hook/gitlab/metrics.go
@@ -24,11 +24,7 @@ func (hp HookProvider) GatherMetrics(r *http.Request, appSlug string) ([]common.
 	}
 
 	currentTime := hp.timeProvider.CurrentTime()
-	metrics, err := hp.gatherMetrics(event, appSlug, currentTime), nil
-	if err != nil {
-		return nil, err
-	}
-
+	metrics := hp.gatherMetrics(event, appSlug, currentTime)
 	return []common.Metrics{metrics}, nil
 }
 

--- a/service/hook/gitlab/metrics.go
+++ b/service/hook/gitlab/metrics.go
@@ -25,6 +25,9 @@ func (hp HookProvider) GatherMetrics(r *http.Request, appSlug string) ([]common.
 
 	currentTime := hp.timeProvider.CurrentTime()
 	metrics := hp.gatherMetrics(event, appSlug, currentTime)
+	if metrics == nil {
+		return nil, nil
+	}
 	return []common.Metrics{metrics}, nil
 }
 

--- a/service/hook/gitlab/metrics.go
+++ b/service/hook/gitlab/metrics.go
@@ -11,7 +11,7 @@ import (
 )
 
 // GatherMetrics ...
-func (hp HookProvider) GatherMetrics(r *http.Request, appSlug string) (common.Metrics, error) {
+func (hp HookProvider) GatherMetrics(r *http.Request, appSlug string) ([]common.Metrics, error) {
 	payload, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
@@ -24,7 +24,12 @@ func (hp HookProvider) GatherMetrics(r *http.Request, appSlug string) (common.Me
 	}
 
 	currentTime := hp.timeProvider.CurrentTime()
-	return hp.gatherMetrics(event, appSlug, currentTime), nil
+	metrics, err := hp.gatherMetrics(event, appSlug, currentTime), nil
+	if err != nil {
+		return nil, err
+	}
+
+	return []common.Metrics{metrics}, nil
 }
 
 func (hp HookProvider) gatherMetrics(event interface{}, appSlug string, currentTime time.Time) common.Metrics {

--- a/service/hook/gitlab/metrics.go
+++ b/service/hook/gitlab/metrics.go
@@ -113,7 +113,7 @@ func newGeneralPullRequestMetrics(pullRequest *gitlab.MergeEvent) common.General
 		TargetBranch:     pullRequest.ObjectAttributes.TargetBranch,
 		CommitID:         pullRequest.ObjectAttributes.LastCommit.ID,
 		MergeCommitSHA:   pullRequest.ObjectAttributes.MergeCommitSHA,
-		Status:           pullRequest.ObjectAttributes.State,
+		Status:           pullRequest.ObjectAttributes.State, // opened, closed, locked, or merged
 	}
 }
 

--- a/service/hook/gitlab/metrics.go
+++ b/service/hook/gitlab/metrics.go
@@ -24,14 +24,12 @@ func (hp HookProvider) GatherMetrics(r *http.Request, appSlug string) ([]common.
 	}
 
 	currentTime := hp.timeProvider.CurrentTime()
-	metrics := hp.gatherMetrics(event, appSlug, currentTime)
-	if metrics == nil {
-		return nil, nil
-	}
-	return []common.Metrics{metrics}, nil
+	metricsList := hp.gatherMetrics(event, appSlug, currentTime)
+	return metricsList, nil
+
 }
 
-func (hp HookProvider) gatherMetrics(event interface{}, appSlug string, currentTime time.Time) common.Metrics {
+func (hp HookProvider) gatherMetrics(event interface{}, appSlug string, currentTime time.Time) []common.Metrics {
 	var metrics common.Metrics
 	switch event := event.(type) {
 	case *gitlab.PushEvent:
@@ -40,7 +38,11 @@ func (hp HookProvider) gatherMetrics(event interface{}, appSlug string, currentT
 		metrics = newPullRequestMetrics(event, appSlug, currentTime)
 	}
 
-	return metrics
+	if metrics == nil {
+		return nil
+	}
+
+	return []common.Metrics{metrics}
 }
 
 func newPullRequestMetrics(event *gitlab.MergeEvent, appSlug string, currentTime time.Time) common.PullRequestMetrics {

--- a/vendor/github.com/go-playground/webhooks/v6/LICENSE
+++ b/vendor/github.com/go-playground/webhooks/v6/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Dean Karn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/go-playground/webhooks/v6/bitbucket/bitbucket.go
+++ b/vendor/github.com/go-playground/webhooks/v6/bitbucket/bitbucket.go
@@ -1,0 +1,204 @@
+package bitbucket
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+// parse errors
+var (
+	ErrEventNotSpecifiedToParse = errors.New("no Event specified to parse")
+	ErrInvalidHTTPMethod        = errors.New("invalid HTTP Method")
+	ErrMissingHookUUIDHeader    = errors.New("missing X-Hook-UUID Header")
+	ErrMissingEventKeyHeader    = errors.New("missing X-Event-Key Header")
+	ErrEventNotFound            = errors.New("event not defined to be parsed")
+	ErrParsingPayload           = errors.New("error parsing payload")
+	ErrUUIDVerificationFailed   = errors.New("UUID verification failed")
+)
+
+// Webhook instance contains all methods needed to process events
+type Webhook struct {
+	uuid string
+}
+
+// Event defines a Bitbucket hook event type
+type Event string
+
+// Bitbucket hook types
+const (
+	RepoPushEvent                  Event = "repo:push"
+	RepoForkEvent                  Event = "repo:fork"
+	RepoUpdatedEvent               Event = "repo:updated"
+	RepoCommitCommentCreatedEvent  Event = "repo:commit_comment_created"
+	RepoCommitStatusCreatedEvent   Event = "repo:commit_status_created"
+	RepoCommitStatusUpdatedEvent   Event = "repo:commit_status_updated"
+	IssueCreatedEvent              Event = "issue:created"
+	IssueUpdatedEvent              Event = "issue:updated"
+	IssueCommentCreatedEvent       Event = "issue:comment_created"
+	PullRequestCreatedEvent        Event = "pullrequest:created"
+	PullRequestUpdatedEvent        Event = "pullrequest:updated"
+	PullRequestApprovedEvent       Event = "pullrequest:approved"
+	PullRequestUnapprovedEvent     Event = "pullrequest:unapproved"
+	PullRequestMergedEvent         Event = "pullrequest:fulfilled"
+	PullRequestDeclinedEvent       Event = "pullrequest:rejected"
+	PullRequestCommentCreatedEvent Event = "pullrequest:comment_created"
+	PullRequestCommentUpdatedEvent Event = "pullrequest:comment_updated"
+	PullRequestCommentDeletedEvent Event = "pullrequest:comment_deleted"
+)
+
+// Option is a configuration option for the webhook
+type Option func(*Webhook) error
+
+// Options is a namespace var for configuration options
+var Options = WebhookOptions{}
+
+// WebhookOptions is a namespace for configuration option methods
+type WebhookOptions struct{}
+
+// UUID registers the BitBucket secret
+func (WebhookOptions) UUID(uuid string) Option {
+	return func(hook *Webhook) error {
+		hook.uuid = uuid
+		return nil
+	}
+}
+
+// New creates and returns a WebHook instance denoted by the Provider type
+func New(options ...Option) (*Webhook, error) {
+	hook := new(Webhook)
+	for _, opt := range options {
+		if err := opt(hook); err != nil {
+			return nil, errors.New("Error applying Option")
+		}
+	}
+	return hook, nil
+}
+
+// Parse verifies and parses the events specified and returns the payload object or an error
+func (hook Webhook) Parse(r *http.Request, events ...Event) (interface{}, error) {
+	defer func() {
+		_, _ = io.Copy(ioutil.Discard, r.Body)
+		_ = r.Body.Close()
+	}()
+
+	if len(events) == 0 {
+		return nil, ErrEventNotSpecifiedToParse
+	}
+	if r.Method != http.MethodPost {
+		return nil, ErrInvalidHTTPMethod
+	}
+
+	uuid := r.Header.Get("X-Hook-UUID")
+	if hook.uuid != "" && uuid == "" {
+		return nil, ErrMissingHookUUIDHeader
+	}
+
+	event := r.Header.Get("X-Event-Key")
+	if event == "" {
+		return nil, ErrMissingEventKeyHeader
+	}
+
+	if len(hook.uuid) > 0 && uuid != hook.uuid {
+		return nil, ErrUUIDVerificationFailed
+	}
+
+	bitbucketEvent := Event(event)
+
+	var found bool
+	for _, evt := range events {
+		if evt == bitbucketEvent {
+			found = true
+			break
+		}
+	}
+	// event not defined to be parsed
+	if !found {
+		return nil, ErrEventNotFound
+	}
+
+	payload, err := ioutil.ReadAll(r.Body)
+	if err != nil || len(payload) == 0 {
+		return nil, ErrParsingPayload
+	}
+
+	switch bitbucketEvent {
+	case RepoPushEvent:
+		var pl RepoPushPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case RepoForkEvent:
+		var pl RepoForkPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case RepoUpdatedEvent:
+		var pl RepoUpdatedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case RepoCommitCommentCreatedEvent:
+		var pl RepoCommitCommentCreatedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case RepoCommitStatusCreatedEvent:
+		var pl RepoCommitStatusCreatedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case RepoCommitStatusUpdatedEvent:
+		var pl RepoCommitStatusUpdatedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case IssueCreatedEvent:
+		var pl IssueCreatedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case IssueUpdatedEvent:
+		var pl IssueUpdatedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case IssueCommentCreatedEvent:
+		var pl IssueCommentCreatedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestCreatedEvent:
+		var pl PullRequestCreatedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestUpdatedEvent:
+		var pl PullRequestUpdatedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestApprovedEvent:
+		var pl PullRequestApprovedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestUnapprovedEvent:
+		var pl PullRequestUnapprovedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestMergedEvent:
+		var pl PullRequestMergedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestDeclinedEvent:
+		var pl PullRequestDeclinedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestCommentCreatedEvent:
+		var pl PullRequestCommentCreatedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestCommentUpdatedEvent:
+		var pl PullRequestCommentUpdatedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	case PullRequestCommentDeletedEvent:
+		var pl PullRequestCommentDeletedPayload
+		err = json.Unmarshal([]byte(payload), &pl)
+		return pl, err
+	default:
+		return nil, fmt.Errorf("unknown event %s", bitbucketEvent)
+	}
+}

--- a/vendor/github.com/go-playground/webhooks/v6/bitbucket/payload.go
+++ b/vendor/github.com/go-playground/webhooks/v6/bitbucket/payload.go
@@ -1,0 +1,510 @@
+package bitbucket
+
+import "time"
+
+// RepoPushPayload is the Bitbucket repo:push payload
+type RepoPushPayload struct {
+	Actor      Owner      `json:"actor"`
+	Repository Repository `json:"repository"`
+	Push       struct {
+		Changes []struct {
+			New struct {
+				Type   string `json:"type"`
+				Name   string `json:"name"`
+				Target struct {
+					Type    string    `json:"type"`
+					Hash    string    `json:"hash"`
+					Author  Owner     `json:"author"`
+					Message string    `json:"message"`
+					Date    time.Time `json:"date"`
+					Parents []struct {
+						Type  string `json:"type"`
+						Hash  string `json:"hash"`
+						Links struct {
+							Self struct {
+								Href string `json:"href"`
+							} `json:"self"`
+							HTML struct {
+								Href string `json:"href"`
+							} `json:"html"`
+						} `json:"links"`
+					} `json:"parents"`
+					Links struct {
+						Self struct {
+							Href string `json:"href"`
+						} `json:"self"`
+						HTML struct {
+							Href string `json:"href"`
+						} `json:"html"`
+					} `json:"links"`
+				} `json:"target"`
+				Links struct {
+					Self struct {
+						Href string `json:"href"`
+					} `json:"self"`
+					Commits struct {
+						Href string `json:"href"`
+					} `json:"commits"`
+					HTML struct {
+						Href string `json:"href"`
+					} `json:"html"`
+				} `json:"links"`
+			} `json:"new"`
+			Old struct {
+				Type   string `json:"type"`
+				Name   string `json:"name"`
+				Target struct {
+					Type    string    `json:"type"`
+					Hash    string    `json:"hash"`
+					Author  Owner     `json:"author"`
+					Message string    `json:"message"`
+					Date    time.Time `json:"date"`
+					Parents []struct {
+						Type  string `json:"type"`
+						Hash  string `json:"hash"`
+						Links struct {
+							Self struct {
+								Href string `json:"href"`
+							} `json:"self"`
+							HTML struct {
+								Href string `json:"href"`
+							} `json:"html"`
+						} `json:"links"`
+					} `json:"parents"`
+					Links struct {
+						Self struct {
+							Href string `json:"href"`
+						} `json:"self"`
+						HTML struct {
+							Href string `json:"href"`
+						} `json:"html"`
+					} `json:"links"`
+				} `json:"target"`
+				Links struct {
+					Self struct {
+						Href string `json:"href"`
+					} `json:"self"`
+					Commits struct {
+						Href string `json:"href"`
+					} `json:"commits"`
+					HTML struct {
+						Href string `json:"href"`
+					} `json:"html"`
+				} `json:"links"`
+			} `json:"old"`
+			Links struct {
+				HTML struct {
+					Href string `json:"href"`
+				} `json:"html"`
+				Diff struct {
+					Href string `json:"href"`
+				} `json:"diff"`
+				Commits struct {
+					Href string `json:"href"`
+				} `json:"commits"`
+			} `json:"links"`
+			Created bool `json:"created"`
+			Forced  bool `json:"forced"`
+			Closed  bool `json:"closed"`
+			Commits []struct {
+				Hash    string `json:"hash"`
+				Type    string `json:"type"`
+				Message string `json:"message"`
+				Author  Owner  `json:"author"`
+				Links   struct {
+					Self struct {
+						Href string `json:"href"`
+					} `json:"self"`
+					HTML struct {
+						Href string `json:"href"`
+					} `json:"html"`
+				} `json:"links"`
+			} `json:"commits"`
+			Truncated bool `json:"truncated"`
+		} `json:"changes"`
+	} `json:"push"`
+}
+
+// RepoForkPayload is the Bitbucket repo:fork payload
+type RepoForkPayload struct {
+	Actor      Owner      `json:"actor"`
+	Repository Repository `json:"repository"`
+	Fork       Repository `json:"fork"`
+}
+
+// RepoUpdatedPayload is the Bitbucket repo:updated payload
+type RepoUpdatedPayload struct {
+	Actor      Owner      `json:"actor"`
+	Repository Repository `json:"repository"`
+	Changes    struct {
+		Name struct {
+			New string `json:"new"`
+			Old string `json:"old"`
+		} `json:"name"`
+		Website struct {
+			New string `json:"new"`
+			Old string `json:"old"`
+		} `json:"website"`
+		Language struct {
+			New string `json:"new"`
+			Old string `json:"old"`
+		} `json:"language"`
+		Links struct {
+			New struct {
+				Avatar struct {
+					Href string `json:"href"`
+				} `json:"avatar"`
+				Self struct {
+					Href string `json:"href"`
+				} `json:"self"`
+				HTML struct {
+					Href string `json:"href"`
+				} `json:"html"`
+			} `json:"new"`
+			Old struct {
+				Avatar struct {
+					Href string `json:"href"`
+				} `json:"avatar"`
+				Self struct {
+					Href string `json:"href"`
+				} `json:"self"`
+				HTML struct {
+					Href string `json:"href"`
+				} `json:"html"`
+			} `json:"old"`
+		} `json:"links"`
+		Description struct {
+			New string `json:"new"`
+			Old string `json:"old"`
+		} `json:"description"`
+		FullName struct {
+			New string `json:"new"`
+			Old string `json:"old"`
+		} `json:"full_name"`
+	} `json:"changes"`
+}
+
+// RepoCommitCommentCreatedPayload is the Bitbucket repo:commit_comment_created payload
+type RepoCommitCommentCreatedPayload struct {
+	Actor      Owner      `json:"actor"`
+	Comment    Comment    `json:"comment"`
+	Repository Repository `json:"repository"`
+	Commit     struct {
+		Hash string `json:"hash"`
+	} `json:"commit"`
+}
+
+// RepoCommitStatusCreatedPayload is the Bitbucket repo:commit_status_created payload
+type RepoCommitStatusCreatedPayload struct {
+	Actor        Owner      `json:"actor"`
+	Repository   Repository `json:"repository"`
+	CommitStatus struct {
+		Name        string    `json:"name"`
+		Description string    `json:"description"`
+		State       string    `json:"state"`
+		Key         string    `json:"key"`
+		URL         string    `json:"url"`
+		Type        string    `json:"type"`
+		CreatedOn   time.Time `json:"created_on"`
+		UpdatedOn   time.Time `json:"updated_on"`
+		Links       struct {
+			Commit struct {
+				Href string `json:"href"`
+			} `json:"commit"`
+			Self struct {
+				Href string `json:"href"`
+			} `json:"self"`
+		} `json:"links"`
+	} `json:"commit_status"`
+}
+
+// RepoCommitStatusUpdatedPayload is the Bitbucket repo:commit_status_updated payload
+type RepoCommitStatusUpdatedPayload struct {
+	Actor        Owner      `json:"actor"`
+	Repository   Repository `json:"repository"`
+	CommitStatus struct {
+		Name        string    `json:"name"`
+		Description string    `json:"description"`
+		State       string    `json:"state"`
+		Key         string    `json:"key"`
+		URL         string    `json:"url"`
+		Type        string    `json:"type"`
+		CreatedOn   time.Time `json:"created_on"`
+		UpdatedOn   time.Time `json:"updated_on"`
+		Links       struct {
+			Commit struct {
+				Href string `json:"href"`
+			} `json:"commit"`
+			Self struct {
+				Href string `json:"href"`
+			} `json:"self"`
+		} `json:"links"`
+	} `json:"commit_status"`
+}
+
+// IssueCreatedPayload is the Bitbucket issue:created payload
+type IssueCreatedPayload struct {
+	Actor      Owner      `json:"actor"`
+	Issue      Issue      `json:"issue"`
+	Repository Repository `json:"repository"`
+}
+
+// IssueUpdatedPayload is the Bitbucket issue:updated payload
+type IssueUpdatedPayload struct {
+	Actor      Owner      `json:"actor"`
+	Issue      Issue      `json:"issue"`
+	Repository Repository `json:"repository"`
+	Comment    Comment    `json:"comment"`
+	Changes    struct {
+		Status struct {
+			Old string `json:"old"`
+			New string `json:"new"`
+		} `json:"status"`
+	} `json:"changes"`
+}
+
+// IssueCommentCreatedPayload is the Bitbucket pullrequest:created payload
+type IssueCommentCreatedPayload struct {
+	Actor      Owner      `json:"actor"`
+	Repository Repository `json:"repository"`
+	Issue      Issue      `json:"issue"`
+	Comment    Comment    `json:"comment"`
+}
+
+// PullRequestCreatedPayload is the Bitbucket pullrequest:created payload
+type PullRequestCreatedPayload struct {
+	Actor       Owner       `json:"actor"`
+	PullRequest PullRequest `json:"pullrequest"`
+	Repository  Repository  `json:"repository"`
+}
+
+// PullRequestUpdatedPayload is the Bitbucket pullrequest:updated payload
+type PullRequestUpdatedPayload struct {
+	Actor       Owner       `json:"actor"`
+	PullRequest PullRequest `json:"pullrequest"`
+	Repository  Repository  `json:"repository"`
+}
+
+// PullRequestApprovedPayload is the Bitbucket pullrequest:approved payload
+type PullRequestApprovedPayload struct {
+	Actor       Owner       `json:"actor"`
+	PullRequest PullRequest `json:"pullrequest"`
+	Repository  Repository  `json:"repository"`
+	Approval    struct {
+		Date time.Time `json:"date"`
+		User Owner     `json:"user"`
+	} `json:"approval"`
+}
+
+// PullRequestUnapprovedPayload is the Bitbucket pullrequest:unapproved payload
+type PullRequestUnapprovedPayload struct {
+	Actor       Owner       `json:"actor"`
+	PullRequest PullRequest `json:"pullrequest"`
+	Repository  Repository  `json:"repository"`
+	Approval    struct {
+		Date time.Time `json:"date"`
+		User Owner     `json:"user"`
+	} `json:"approval"`
+}
+
+// PullRequestMergedPayload is the Bitbucket pullrequest:fulfilled payload
+type PullRequestMergedPayload struct {
+	Actor       Owner       `json:"actor"`
+	PullRequest PullRequest `json:"pullrequest"`
+	Repository  Repository  `json:"repository"`
+}
+
+// PullRequestDeclinedPayload is the Bitbucket pullrequest:rejected payload
+type PullRequestDeclinedPayload struct {
+	Actor       Owner       `json:"actor"`
+	PullRequest PullRequest `json:"pullrequest"`
+	Repository  Repository  `json:"repository"`
+}
+
+// PullRequestCommentCreatedPayload is the Bitbucket pullrequest:comment_updated payload
+type PullRequestCommentCreatedPayload struct {
+	Actor       Owner       `json:"actor"`
+	Repository  Repository  `json:"repository"`
+	PullRequest PullRequest `json:"pullrequest"`
+	Comment     Comment     `json:"comment"`
+}
+
+// PullRequestCommentUpdatedPayload is the Bitbucket pullrequest:comment_created payload
+type PullRequestCommentUpdatedPayload struct {
+	Actor       Owner       `json:"actor"`
+	Repository  Repository  `json:"repository"`
+	PullRequest PullRequest `json:"pullrequest"`
+	Comment     Comment     `json:"comment"`
+}
+
+// PullRequestCommentDeletedPayload is the Bitbucket pullrequest:comment_deleted payload
+type PullRequestCommentDeletedPayload struct {
+	Actor       Owner       `json:"actor"`
+	Repository  Repository  `json:"repository"`
+	PullRequest PullRequest `json:"pullrequest"`
+	Comment     Comment     `json:"comment"`
+}
+
+// Owner is the common Bitbucket Owner Sub Entity
+type Owner struct {
+	Type        string `json:"type"`
+	NickName    string `json:"nickname"`
+	DisplayName string `json:"display_name"`
+	AccountID   string `json:"account_id"`
+	UUID        string `json:"uuid"`
+	Links       struct {
+		Self struct {
+			Href string `json:"href"`
+		} `json:"self"`
+		HTML struct {
+			Href string `json:"href"`
+		} `json:"html"`
+		Avatar struct {
+			Href string `json:"href"`
+		} `json:"avatar"`
+	} `json:"links"`
+}
+
+// Repository is the common Bitbucket Repository Sub Entity
+type Repository struct {
+	Type  string `json:"type"`
+	Links struct {
+		Self struct {
+			Href string `json:"href"`
+		} `json:"self"`
+		HTML struct {
+			Href string `json:"href"`
+		} `json:"html"`
+		Avatar struct {
+			Href string `json:"href"`
+		} `json:"avatar"`
+	} `json:"links"`
+	UUID      string  `json:"uuid"`
+	Project   Project `json:"project"`
+	FullName  string  `json:"full_name"`
+	Name      string  `json:"name"`
+	Website   string  `json:"website"`
+	Owner     Owner   `json:"owner"`
+	Scm       string  `json:"scm"`
+	IsPrivate bool    `json:"is_private"`
+}
+
+// Project is the common Bitbucket Project Sub Entity
+type Project struct {
+	Type    string `json:"type"`
+	Project string `json:"project"`
+	UUID    string `json:"uuid"`
+	Links   struct {
+		HTML struct {
+			Href string `json:"href"`
+		} `json:"html"`
+		Avatar struct {
+			Href string `json:"href"`
+		} `json:"avatar"`
+	} `json:"links"`
+	Key string `json:"key"`
+}
+
+// Issue is the common Bitbucket Issue Sub Entity
+type Issue struct {
+	ID        int64  `json:"id"`
+	Component string `json:"component"`
+	Title     string `json:"title"`
+	Content   struct {
+		Raw    string `json:"raw"`
+		HTML   string `json:"html"`
+		Markup string `json:"markup"`
+	} `json:"content"`
+	Priority  string `json:"priority"`
+	State     string `json:"state"`
+	Type      string `json:"type"`
+	Milestone struct {
+		Name string `json:"name"`
+	} `json:"milestone"`
+	Version struct {
+		Name string `json:"name"`
+	} `json:"version"`
+	CreatedOn time.Time `json:"created_on"`
+	UpdatedOn time.Time `json:"updated_on"`
+	Links     struct {
+		Self struct {
+			Href string `json:"href"`
+		} `json:"self"`
+		HTML struct {
+			Href string `json:"href"`
+		} `json:"html"`
+	} `json:"links"`
+}
+
+// Comment is the common Bitbucket Comment Sub Entity
+type Comment struct {
+	ID     int64 `json:"id"`
+	Parent struct {
+		ID int64 `json:"id"`
+	} `json:"parent"`
+	Content struct {
+		Raw    string `json:"raw"`
+		HTML   string `json:"html"`
+		Markup string `json:"markup"`
+	} `json:"content"`
+	Inline struct {
+		Path string `json:"path"`
+		From *int64 `json:"from"`
+		To   int64  `json:"to"`
+	} `json:"inline"`
+	CreatedOn time.Time `json:"created_on"`
+	UpdatedOn time.Time `json:"updated_on"`
+	Links     struct {
+		Self struct {
+			Href string `json:"href"`
+		} `json:"self"`
+		HTML struct {
+			Href string `json:"href"`
+		} `json:"html"`
+	} `json:"links"`
+}
+
+// PullRequest is the common Bitbucket Pull Request Sub Entity
+type PullRequest struct {
+	ID          int64  `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	State       string `json:"state"`
+	Author      Owner  `json:"author"`
+	Source      struct {
+		Branch struct {
+			Name string `json:"name"`
+		} `json:"branch"`
+		Commit struct {
+			Hash string `json:"hash"`
+		} `json:"commit"`
+		Repository Repository `json:"repository"`
+	} `json:"source"`
+	Destination struct {
+		Branch struct {
+			Name string `json:"name"`
+		} `json:"branch"`
+		Commit struct {
+			Hash string `json:"hash"`
+		} `json:"commit"`
+		Repository Repository `json:"repository"`
+	} `json:"destination"`
+	MergeCommit struct {
+		Hash string `json:"hash"`
+	} `json:"merge_commit"`
+	Participants      []Owner   `json:"participants"`
+	Reviewers         []Owner   `json:"reviewers"`
+	CloseSourceBranch bool      `json:"close_source_branch"`
+	ClosedBy          Owner     `json:"closed_by"`
+	Reason            string    `json:"reason"`
+	CreatedOn         time.Time `json:"created_on"`
+	UpdatedOn         time.Time `json:"updated_on"`
+	Links             struct {
+		Self struct {
+			Href string `json:"href"`
+		} `json:"self"`
+		HTML struct {
+			Href string `json:"href"`
+		} `json:"html"`
+	} `json:"links"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -118,6 +118,9 @@ github.com/ebitengine/purego
 github.com/ebitengine/purego/internal/cgo
 github.com/ebitengine/purego/internal/fakecgo
 github.com/ebitengine/purego/internal/strings
+# github.com/go-playground/webhooks/v6 v6.3.0
+## explicit; go 1.15
+github.com/go-playground/webhooks/v6/bitbucket
 # github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 ## explicit
 github.com/golang/groupcache/lru


### PR DESCRIPTION
### New Pull Request Checklist

- [x] Run `go fmt` on your files (e.g. `go fmt ./service/common.go`, or on the whole `service` folder: `go fmt ./service/...`)
- [x] Write tests for your code
  - The tests should cover both "success" and "error" cases.
  - The tests should also check **all the returned variables**, don't ignore any returned value!
  - Ideally the tests should be easily readable, we usually use tests to document our code instead of code comments.
    An example, if you'd write a comment like "Given X this function will return Y" or
    "Beware, if the input is X this function will return Y" then you should implement this as
    a unit test, instead of writing it as a comment.
- [x] If your Pull Request is more than a bug fix you should also check `README.md` and change/add the descriptions there - also
  feel free to add yourself as a contributor if you implement support for a new service ;)
- [x] Before creating the Pull Request you should also run `bitrise run test` with the [Bitrise CLI](https://www.bitrise.io/cli),
  to perform all the automatic checks (which will run on your Pull Request when you open it).


### Summary of Pull Request

This PR [reintroduces Bitbucket metrics](https://github.com/bitrise-io/bitrise-webhooks/pull/147), that had to be [rolled back](https://github.com/bitrise-io/bitrise-webhooks/pull/148), because of a panic, caused by nil pointer issues.

This original change updated `MetricsProvider.GatherMetrics` to return an array of `Metrics`.
GitHub and GitLab implementations of `MetricsProvider` were putting the returned `Metrics` in an array, without checking if `Metrics` is nil. This way the returned metrics array contained nil elements.

This issue is fixed in this commit: https://github.com/bitrise-io/bitrise-webhooks/commit/f7c1c43d8a409cedde262aa702de9550cdccc34a