### PR TITLE
GitLab hook provider adds commit messages as build trigger env vars

### DIFF
--- a/service/hook/endpoint.go
+++ b/service/hook/endpoint.go
@@ -36,14 +36,14 @@ type Client struct {
 	PubsubClient *pubsub.Client
 }
 
-func supportedProviders() map[string]hookCommon.Provider {
+func supportedProviders(logger *zap.Logger) map[string]hookCommon.Provider {
 	return map[string]hookCommon.Provider{
 		github.ProviderID:                   github.NewDefaultHookProvider(),
 		bitbucketv2.ProviderID:              bitbucketv2.NewDefaultHookProvider(),
 		bitbucketserver.ProviderID:          bitbucketserver.HookProvider{},
 		slack.ProviderID:                    slack.HookProvider{},
 		visualstudioteamservices.ProviderID: visualstudioteamservices.HookProvider{},
-		gitlab.ProviderID:                   gitlab.NewDefaultHookProvider(),
+		gitlab.ProviderID:                   gitlab.NewDefaultHookProvider(logger),
 		gogs.ProviderID:                     gogs.HookProvider{},
 		deveo.ProviderID:                    deveo.HookProvider{},
 		assembla.ProviderID:                 assembla.HookProvider{},
@@ -162,7 +162,7 @@ func (c *Client) HTTPHandler(w http.ResponseWriter, r *http.Request) {
 		respondWithErrorString(w, nil, "No service-id defined")
 		return
 	}
-	hookProvider, isSupported := supportedProviders()[serviceID]
+	hookProvider, isSupported := supportedProviders(logger)[serviceID]
 	if !isSupported {
 		respondWithErrorString(w, nil, fmt.Sprintf("Unsupported Webhook Type / Provider: %s", serviceID))
 		return

--- a/service/hook/gitlab/gitlab_test.go
+++ b/service/hook/gitlab/gitlab_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/bitrise-io/bitrise-webhooks/bitriseapi"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 const sampleCodePushData = `{
@@ -188,7 +188,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 				},
 			},
 		}
-		hookTransformResult := transformCodePushEvent(codePush)
+		hookTransformResult := NewDefaultHookProvider(zap.NewNop()).transformCodePushEvent(codePush)
 		require.NoError(t, hookTransformResult.Error)
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
@@ -197,6 +197,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 					CommitHash:    "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
 					CommitMessage: `Response: omit the "failed_responses" array if empty`,
 					Branch:        "master",
+					Environments:  []bitriseapi.EnvironmentItem{{Name: "COMMIT_MESSAGES", Value: `["Response: omit the \"failed_responses\" array if empty"]`, IsExpand: false}},
 				},
 				TriggeredBy: "webhook-gitlab/test_user",
 			},
@@ -226,7 +227,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 				},
 			},
 		}
-		hookTransformResult := transformCodePushEvent(codePush)
+		hookTransformResult := NewDefaultHookProvider(zap.NewNop()).transformCodePushEvent(codePush)
 		require.NoError(t, hookTransformResult.Error)
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
@@ -235,6 +236,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 					CommitHash:    "f8f37818dc89a67516adfc21896d0c9ec43d05c2",
 					CommitMessage: `Response: omit the "failed_responses" array if empty`,
 					Branch:        "master",
+					Environments:  []bitriseapi.EnvironmentItem{{Name: "COMMIT_MESSAGES", Value: `["switch to three component versions","Response: omit the \"failed_responses\" array if empty","get version : three component version"]`, IsExpand: false}},
 				},
 				TriggeredBy: "webhook-gitlab/test_user",
 			},
@@ -256,7 +258,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 				},
 			},
 		}
-		hookTransformResult := transformCodePushEvent(codePush)
+		hookTransformResult := NewDefaultHookProvider(zap.NewNop()).transformCodePushEvent(codePush)
 		require.EqualError(t, hookTransformResult.Error, "The commit specified by 'checkout_sha' was not included in the 'commits' array - no match found")
 		require.False(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
@@ -272,7 +274,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 			UserUsername: "test_user",
 			Commits:      []CommitModel{},
 		}
-		hookTransformResult := transformCodePushEvent(codePush)
+		hookTransformResult := NewDefaultHookProvider(zap.NewNop()).transformCodePushEvent(codePush)
 		require.EqualError(t, hookTransformResult.Error, "The 'checkout_sha' field is not set - potential squashed merge request")
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.Nil(t, hookTransformResult.TriggerAPIParams)
@@ -293,7 +295,7 @@ func Test_transformCodePushEvent(t *testing.T) {
 				},
 			},
 		}
-		hookTransformResult := transformCodePushEvent(codePush)
+		hookTransformResult := NewDefaultHookProvider(zap.NewNop()).transformCodePushEvent(codePush)
 		require.True(t, hookTransformResult.ShouldSkip)
 		require.EqualError(t, hookTransformResult.Error, "Ref (refs/not/head) is not a head ref")
 		require.Nil(t, hookTransformResult.TriggerAPIParams)


### PR DESCRIPTION
### New Pull Request Checklist

- [ ] Run `go fmt` on your files (e.g. `go fmt ./service/common.go`, or on the whole `service` folder: `go fmt ./service/...`)
- [ ] Write tests for your code
  - The tests should cover both "success" and "error" cases.
  - The tests should also check **all the returned variables**, don't ignore any returned value!
  - Ideally the tests should be easily readable, we usually use tests to document our code instead of code comments.
    An example, if you'd write a comment like "Given X this function will return Y" or
    "Beware, if the input is X this function will return Y" then you should implement this as
    a unit test, instead of writing it as a comment.
- [ ] If your Pull Request is more than a bug fix you should also check `README.md` and change/add the descriptions there - also
  feel free to add yourself as a contributor if you implement support for a new service ;)
- [ ] Before creating the Pull Request you should also run `bitrise run test` with the [Bitrise CLI](https://www.bitrise.io/cli),
  to perform all the automatic checks (which will run on your Pull Request when you open it).


### Summary of Pull Request

This PR updates the GitLab hook provider to gather commit messages included in a Push event payload and include them in the Bitrise build trigger params as a JSON array of strings.
