### PR TITLE
[BIVS-2486] don't panic on non-PR issue comments

### DIFF
--- a/service/hook/github/metrics.go
+++ b/service/hook/github/metrics.go
@@ -39,11 +39,23 @@ func (hp HookProvider) gatherMetrics(event interface{}, webhookType, appSlug str
 	var metrics common.Metrics
 	switch event := event.(type) {
 	case *github.PushEvent, *github.DeleteEvent, *github.CreateEvent:
-		metrics = newPushMetrics(event, webhookType, appSlug, currentTime)
+		pushMetrics := newPushMetrics(event, webhookType, appSlug, currentTime)
+		if pushMetrics == nil {
+			return nil
+		}
+		metrics = pushMetrics
 	case *github.PullRequestEvent, *github.PullRequestReviewEvent:
-		metrics = newPullRequestMetrics(event, webhookType, appSlug, currentTime)
+		prMetrics := newPullRequestMetrics(event, webhookType, appSlug, currentTime)
+		if prMetrics == nil {
+			return nil
+		}
+		metrics = prMetrics
 	case *github.PullRequestReviewCommentEvent, *github.PullRequestReviewThreadEvent, *github.IssueCommentEvent:
-		metrics = newPullRequestCommentMetrics(event, webhookType, appSlug, currentTime)
+		commentMetrics := newPullRequestCommentMetrics(event, webhookType, appSlug, currentTime)
+		if commentMetrics == nil {
+			return nil
+		}
+		metrics = commentMetrics
 	}
 
 	if metrics == nil {

--- a/service/hook/github/metrics_test.go
+++ b/service/hook/github/metrics_test.go
@@ -123,6 +123,36 @@ func TestHookProvider_gatherMetrics(t *testing.T) {
 			},
 		},
 		{
+			name: "Pull Request Issue Comment event transformed to Pull Request Comment metrics",
+			event: &github.IssueCommentEvent{
+				Issue: &github.Issue{
+					PullRequestLinks: &github.PullRequestLinks{},
+				},
+			},
+			webhookType: "issue_comment",
+			appSlug:     "slug",
+			want: &common.PullRequestCommentMetrics{
+				Event:  "pull_request",
+				Action: "comment",
+				GeneralMetrics: common.GeneralMetrics{
+					ProviderType:    ProviderID,
+					TimeStamp:       currentTime,
+					AppSlug:         "slug",
+					OriginalTrigger: "issue_comment:",
+				},
+				PullRequestID: "0",
+			},
+		},
+		{
+			name: "Other Issue Comment event not supported",
+			event: &github.IssueCommentEvent{
+				Issue: &github.Issue{},
+			},
+			webhookType: "issue_comment",
+			appSlug:     "slug",
+			want:        nil,
+		},
+		{
 			name:        "Fork event is not supported",
 			event:       &github.ForkEvent{},
 			webhookType: "fork",


### PR DESCRIPTION
Non-PR issue comments return `nil` as metrics, wrapped in an interface so we didn't properly check if it was `nil` until now.