### PR TITLE
add pr:reviewer:approved as a valid event for Bitbucket Server

### DIFF
--- a/service/hook/bitbucketserver/bitbucketserver.go
+++ b/service/hook/bitbucketserver/bitbucketserver.go
@@ -258,7 +258,7 @@ func transformPullRequestEvent(pullRequest PullRequestEventModel) hookCommon.Tra
 }
 
 func isAcceptEventType(eventKey string) bool {
-	return slices.Contains([]string{"repo:refs_changed", "pr:opened", "pr:modified", "pr:merged", "diagnostics:ping", "pr:from_ref_updated"}, eventKey)
+	return slices.Contains([]string{"repo:refs_changed", "pr:opened", "pr:modified", "pr:merged", "diagnostics:ping", "pr:from_ref_updated", "pr:reviewer:approved"}, eventKey)
 }
 
 // TransformRequest ...
@@ -301,7 +301,7 @@ func (hp HookProvider) TransformRequest(r *http.Request) hookCommon.TransformRes
 		return transformPushEvent(pushEvent)
 	}
 
-	if eventKey == "pr:opened" || eventKey == "pr:modified" || eventKey == "pr:merged" || eventKey == "pr:from_ref_updated" {
+	if eventKey == "pr:opened" || eventKey == "pr:modified" || eventKey == "pr:merged" || eventKey == "pr:from_ref_updated" || eventKey == "pr:reviewer:approved" {
 		var pullRequestEvent PullRequestEventModel
 		if err := json.NewDecoder(r.Body).Decode(&pullRequestEvent); err != nil {
 			return hookCommon.TransformResultModel{

--- a/service/hook/bitbucketserver/bitbucketserver_test.go
+++ b/service/hook/bitbucketserver/bitbucketserver_test.go
@@ -519,6 +519,163 @@ const (
 	}
 }`
 
+	samplePullRequestApprovedData = `{
+    "date": "2024-08-08T14:58:09+0200",
+    "actor": {
+        "emailAddress": "user1@example.com",
+        "displayName": "User One",
+        "name": "user1",
+        "active": true,
+        "links": {"self": [{"href": "https://stash-ui.example.com/users/user1"}]},
+        "id": 1,
+        "type": "NORMAL",
+        "slug": "user1"
+    },
+    "eventKey": "pr:reviewer:approved",
+    "pullRequest": {
+        "author": {
+            "approved": false,
+            "role": "AUTHOR",
+            "user": {
+                "emailAddress": "user2@example.com",
+                "displayName": "User Two",
+                "name": "user2",
+                "active": true,
+                "links": {"self": [{"href": "https://stash-ui.example.com/users/user2"}]},
+                "id": 2,
+                "type": "NORMAL",
+                "slug": "user2"
+            },
+            "status": "UNAPPROVED"
+        },
+        "description": "Approved!",
+        "updatedDate": 1723045050014,
+        "title": "fix error",
+        "version": 4,
+        "reviewers": [{
+            "approved": true,
+            "role": "REVIEWER",
+            "user": {
+                "emailAddress": "user1@example.com",
+                "displayName": "User One",
+                "name": "user1",
+                "active": true,
+                "links": {"self": [{"href": "https://stash-ui.example.com/users/user1"}]},
+                "id": 1,
+                "type": "NORMAL",
+                "slug": "user1"
+            },
+            "lastReviewedCommit": "836204e0cbf06ce4ebfb878be21fb383d8c12e62",
+            "status": "APPROVED"
+        }],
+        "toRef": {
+            "latestCommit": "4755079fa762299a4d99512ca18703db80d42a35",
+            "id": "refs/heads/main-branch",
+            "displayId": "main-branch",
+            "type": "BRANCH",
+            "repository": {
+                "archived": false,
+                "public": false,
+                "hierarchyId": "7087f8beac6eb0d81cd8",
+                "name": "app-repo",
+                "forkable": true,
+                "project": {
+                    "public": false,
+                    "name": "Project - Mobile",
+                    "description": "Internal mobile repository",
+                    "links": {"self": [{"href": "https://stash-ui.example.com/projects/PROJ"}]},
+                    "id": 1,
+                    "type": "NORMAL",
+                    "key": "PROJ"
+                },
+                "links": {
+                    "clone": [
+                        {
+                            "name": "http",
+                            "href": "https://stash-ui.example.com/scm/proj/app-repo.git"
+                        },
+                        {
+                            "name": "ssh",
+                            "href": "ssh://git@stash.example.com:7999/proj/app-repo.git"
+                        }
+                    ],
+                    "self": [{"href": "https://stash-ui.example.com/projects/PROJ/repos/app-repo/browse"}]
+                },
+                "id": 84,
+                "scmId": "git",
+                "state": "AVAILABLE",
+                "slug": "app-repo",
+                "statusMessage": "Available"
+            }
+        },
+        "createdDate": 1723023559286,
+        "closed": false,
+        "fromRef": {
+            "latestCommit": "836204e0cbf06ce4ebfb878be21fb383d8c12e62",
+            "id": "refs/heads/test-fix-error",
+            "displayId": "test-fix-error",
+            "type": "BRANCH",
+            "repository": {
+                "archived": false,
+                "public": false,
+                "hierarchyId": "7087f8beac6eb0d81cd8",
+                "name": "app-repo",
+                "forkable": true,
+                "project": {
+                    "public": false,
+                    "name": "Project - Mobile",
+                    "description": "Internal mobile repository",
+                    "links": {"self": [{"href": "https://stash-ui.example.com/projects/PROJ"}]},
+                    "id": 1,
+                    "type": "NORMAL",
+                    "key": "PROJ"
+                },
+                "links": {
+                    "clone": [
+                        {
+                            "name": "http",
+                            "href": "https://stash-ui.example.com/scm/proj/app-repo.git"
+                        },
+                        {
+                            "name": "ssh",
+                            "href": "ssh://git@stash.example.com:7999/proj/app-repo.git"
+                        }
+                    ],
+                    "self": [{"href": "https://stash-ui.example.com/projects/PROJ/repos/app-repo/browse"}]
+                },
+                "id": 84,
+                "scmId": "git",
+                "state": "AVAILABLE",
+                "slug": "app-repo",
+                "statusMessage": "Available"
+            }
+        },
+        "links": {"self": [{"href": "https://stash-ui.example.com/projects/PROJ/repos/app-repo/pull-requests/1"}]},
+        "id": 1,
+        "state": "OPEN",
+        "locked": false,
+        "open": true,
+        "participants": []
+    },
+    "participant": {
+        "approved": true,
+        "role": "REVIEWER",
+        "user": {
+            "emailAddress": "user1@example.com",
+            "displayName": "User One",
+            "name": "user1",
+            "active": true,
+            "links": {"self": [{"href": "https://stash-ui.example.com/users/user1"}]},
+            "id": 1,
+            "type": "NORMAL",
+            "slug": "user1"
+        },
+        "lastReviewedCommit": "836204e0cbf06ce4ebfb878be21fb383d8c12e62",
+        "status": "APPROVED"
+    },
+    "previousStatus": "NEEDS_WORK"
+}`
+
 	samplePingData = `{
 	"test": true
 }`
@@ -1193,7 +1350,7 @@ func Test_isAcceptEventType(t *testing.T) {
 	{
 		for _, anAction := range []string{"",
 			"a", "not-an-action",
-			"repo:forked", "repo:modified", "repo:comment:added", "repo:comment:edited", "repo:comment:deleted", "pr:reviewer:approved",
+			"repo:forked", "repo:modified", "repo:comment:added", "repo:comment:edited", "repo:comment:deleted",
 			"pr:reviewer:unapproved", "pr:reviewer:needs_work", "pr:declined", "pr:deleted",
 			"pr:comment:added", "pr:comment:updated", "pr:comment:deleted",
 		} {
@@ -1396,6 +1553,33 @@ func Test_HookProvider_TransformRequest(t *testing.T) {
 					PullRequestID: &intOne,
 				},
 				TriggeredBy: "webhook-bitbucket-server/admin",
+			},
+		}, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)
+	}
+
+	t.Log("Test with Sample Pull Request approved Data")
+	{
+		request := http.Request{
+			Header: http.Header{
+				"X-Event-Key":  {"pr:reviewer:approved"},
+				"Content-Type": {"application/json; charset=utf-8"},
+			},
+			Body: ioutil.NopCloser(strings.NewReader(samplePullRequestApprovedData)),
+		}
+		hookTransformResult := provider.TransformRequest(&request)
+		require.NoError(t, hookTransformResult.Error)
+		require.False(t, hookTransformResult.ShouldSkip)
+		require.Equal(t, []bitriseapi.TriggerAPIParamsModel{
+			{
+				BuildParams: bitriseapi.BuildParamsModel{
+					CommitHash:    "836204e0cbf06ce4ebfb878be21fb383d8c12e62",
+					CommitMessage: "fix error",
+					Branch:        "test-fix-error",
+					BranchDest:    "main-branch",
+					PullRequestID: &intOne,
+				},
+				TriggeredBy: "webhook-bitbucket-server/user1",
 			},
 		}, hookTransformResult.TriggerAPIParams)
 		require.Equal(t, false, hookTransformResult.DontWaitForTriggerResponse)


### PR DESCRIPTION
### New Pull Request Checklist

- [X] Run `go fmt` on your files (e.g. `go fmt ./service/common.go`, or on the whole `service` folder: `go fmt ./service/...`)
- [X] Write tests for your code
  - The tests should cover both "success" and "error" cases.
  - The tests should also check **all the returned variables**, don't ignore any returned value!
  - Ideally the tests should be easily readable, we usually use tests to document our code instead of code comments.
    An example, if you'd write a comment like "Given X this function will return Y" or
    "Beware, if the input is X this function will return Y" then you should implement this as
    a unit test, instead of writing it as a comment.
- [N/A] If your Pull Request is more than a bug fix you should also check `README.md` and change/add the descriptions there - also
  feel free to add yourself as a contributor if you implement support for a new service ;)
- [X] Before creating the Pull Request you should also run `bitrise run test` with the [Bitrise CLI](https://www.bitrise.io/cli),
  to perform all the automatic checks (which will run on your Pull Request when you open it).


### Summary of Pull Request

This Pull Request adds support for the pr:reviewer:approved event so that when our webhook sends out this event, a build can get triggered. 
We personally want to have this support as we only want to start a build when somebody approves the PR.
