### PR TITLE
[BIVS-2946] Don't reply with 400 to an empty push from GitLab

### DIFF
--- a/service/hook/gitlab/gitlab.go
+++ b/service/hook/gitlab/gitlab.go
@@ -311,6 +311,14 @@ func (hp HookProvider) transformCodePushEvent(codePushEvent CodePushEventModel) 
 		}
 	}
 
+	if len(codePushEvent.Commits) == 0 {
+		return hookCommon.TransformResultModel{
+			DontWaitForTriggerResponse: true,
+			Error:                      fmt.Errorf("Empty 'commits' array - probably created a branch with no commits yet"),
+			ShouldSkip:                 true,
+		}
+	}
+
 	lastCommit := CommitModel{}
 	isLastCommitFound := false
 	for _, aCommit := range codePushEvent.Commits {

--- a/service/hook/gitlab/gitlab_test.go
+++ b/service/hook/gitlab/gitlab_test.go
@@ -927,6 +927,22 @@ func Test_transformCodePushEvent(t *testing.T) {
 		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
 	}
 
+	t.Log("No  commits (branch creation)")
+	{
+		codePush := CodePushEventModel{
+			ObjectKind:   "push",
+			Ref:          "refs/heads/master",
+			CheckoutSHA:  "checkout-sha",
+			UserUsername: "test_user",
+			Commits:      []CommitModel{},
+		}
+		hookTransformResult := NewDefaultHookProvider(zap.NewNop()).transformCodePushEvent(codePush)
+		require.EqualError(t, hookTransformResult.Error, "Empty 'commits' array - probably created a branch with no commits yet")
+		require.True(t, hookTransformResult.ShouldSkip)
+		require.Nil(t, hookTransformResult.TriggerAPIParams)
+		require.Equal(t, true, hookTransformResult.DontWaitForTriggerResponse)
+	}
+
 	t.Log("Commit without CheckoutSHA (squashed merge request)")
 	{
 		codePush := CodePushEventModel{


### PR DESCRIPTION
Creating a branch from the GitLab UI results in a push event with no commits in the payload. Instead of a 400, just skip the build with a message.