### PR TITLE
[BIVS-3372] check for skip ci in PR comments too

### DIFF
--- a/service/hook/bitbucketv2/bitbucketv2.go
+++ b/service/hook/bitbucketv2/bitbucketv2.go
@@ -309,8 +309,8 @@ func transformPullRequestEvent(pullRequest PullRequestEventModel) hookCommon.Tra
 				TriggeredBy: hookCommon.GenerateTriggeredBy(ProviderID, pullRequest.PullRequestInfo.Author.Nickname),
 			},
 		},
-		SkippedByPrDescription: !hookCommon.IsSkipBuildByCommitMessage(pullRequest.PullRequestInfo.Title) &&
-			hookCommon.IsSkipBuildByCommitMessage(pullRequest.PullRequestInfo.Description),
+		SkippedByPrDescription: !hookCommon.ContainsSkipInstruction(pullRequest.PullRequestInfo.Title) &&
+			hookCommon.ContainsSkipInstruction(pullRequest.PullRequestInfo.Description),
 	}
 }
 

--- a/service/hook/common/common.go
+++ b/service/hook/common/common.go
@@ -30,7 +30,7 @@ type TransformResultModel struct {
 	// TriggerAPIParams is the transformed Bitrise Trigger API params
 	TriggerAPIParams []bitriseapi.TriggerAPIParamsModel
 	// ShouldSkip if true then no build should be started for this webhook
-	//  but we should respond with a succcess HTTP status code
+	//  but we should respond with a success HTTP status code
 	ShouldSkip bool
 	// Error in transforming the hook. If ShouldSkip=true this is
 	//  the reason why the hook should be skipped.

--- a/service/hook/common/skipci.go
+++ b/service/hook/common/skipci.go
@@ -2,8 +2,8 @@ package common
 
 import "strings"
 
-// IsSkipBuildByCommitMessage ...
-func IsSkipBuildByCommitMessage(commitMsg string) bool {
+// ContainsSkipInstruction ...
+func ContainsSkipInstruction(commitMsg string) bool {
 	if checkSkipPatternPair(commitMsg, "ci", "skip") {
 		return true
 	}

--- a/service/hook/common/skipci_test.go
+++ b/service/hook/common/skipci_test.go
@@ -24,7 +24,7 @@ line too`,
 			`this message has \\[skip bitrise\\] because of markdown`,
 		} {
 			t.Log(" * Commit message:", aCommitMsg)
-			require.Equal(t, true, IsSkipBuildByCommitMessage(aCommitMsg))
+			require.Equal(t, true, ContainsSkipInstruction(aCommitMsg))
 		}
 	}
 
@@ -38,7 +38,7 @@ line too`,
 			"this won't be skipped either: [ bitrise skip ]",
 		} {
 			t.Log(" * Commit message:", aCommitMsg)
-			require.Equal(t, false, IsSkipBuildByCommitMessage(aCommitMsg))
+			require.Equal(t, false, ContainsSkipInstruction(aCommitMsg))
 		}
 	}
 }
@@ -61,7 +61,7 @@ line too`,
 			`this message has \\[skip ci\\] because of markdown`,
 		} {
 			t.Log(" * Commit message:", aCommitMsg)
-			require.Equal(t, true, IsSkipBuildByCommitMessage(aCommitMsg))
+			require.Equal(t, true, ContainsSkipInstruction(aCommitMsg))
 		}
 	}
 
@@ -75,7 +75,7 @@ line too`,
 			"this won't be skipped either: [ ci skip ]",
 		} {
 			t.Log(" * Commit message:", aCommitMsg)
-			require.Equal(t, false, IsSkipBuildByCommitMessage(aCommitMsg))
+			require.Equal(t, false, ContainsSkipInstruction(aCommitMsg))
 		}
 	}
 }

--- a/service/hook/endpoint.go
+++ b/service/hook/endpoint.go
@@ -276,9 +276,17 @@ func (c *Client) HTTPHandler(w http.ResponseWriter, r *http.Request) {
 		for _, aBuildTriggerParam := range hookTransformResult.TriggerAPIParams {
 			commitMessage := aBuildTriggerParam.BuildParams.CommitMessage
 
-			if hookCommon.IsSkipBuildByCommitMessage(commitMessage) {
+			if hookCommon.ContainsSkipInstruction(commitMessage) {
 				respondWith.SkippedTriggerResponses = append(respondWith.SkippedTriggerResponses, hookCommon.SkipAPIResponseModel{
 					Message:       "Build skipped because the commit message included a skip ci keyword ([skip ci] or [ci skip]).",
+					CommitHash:    aBuildTriggerParam.BuildParams.CommitHash,
+					CommitMessage: aBuildTriggerParam.BuildParams.CommitMessage,
+					Branch:        aBuildTriggerParam.BuildParams.Branch,
+				})
+				continue
+			} else if hookCommon.ContainsSkipInstruction(aBuildTriggerParam.BuildParams.PullRequestComment) {
+				respondWith.SkippedTriggerResponses = append(respondWith.SkippedTriggerResponses, hookCommon.SkipAPIResponseModel{
+					Message:       "Build skipped because the PR comment included a skip ci keyword ([skip ci] or [ci skip]).",
 					CommitHash:    aBuildTriggerParam.BuildParams.CommitHash,
 					CommitMessage: aBuildTriggerParam.BuildParams.CommitMessage,
 					Branch:        aBuildTriggerParam.BuildParams.Branch,

--- a/service/hook/github/github.go
+++ b/service/hook/github/github.go
@@ -268,7 +268,7 @@ func transformPullRequestEvent(pullRequest PullRequestEventModel) hookCommon.Tra
 	if pullRequest.Action == "edited" {
 		// skip it if only title / description changed, and the previous pattern did not include a [skip ci] pattern
 		if pullRequest.Changes.Base == nil {
-			if !hookCommon.IsSkipBuildByCommitMessage(pullRequest.Changes.Title.From) && !hookCommon.IsSkipBuildByCommitMessage(pullRequest.Changes.Body.From) {
+			if !hookCommon.ContainsSkipInstruction(pullRequest.Changes.Title.From) && !hookCommon.ContainsSkipInstruction(pullRequest.Changes.Body.From) {
 				return hookCommon.TransformResultModel{
 					Error:      errors.New("pull Request edit doesn't require a build: only title and/or description was changed, and previous one was not skipped"),
 					ShouldSkip: true,
@@ -355,8 +355,8 @@ func transformPullRequestEvent(pullRequest PullRequestEventModel) hookCommon.Tra
 		TriggerAPIParams: []bitriseapi.TriggerAPIParamsModel{
 			result,
 		},
-		SkippedByPrDescription: !hookCommon.IsSkipBuildByCommitMessage(pullRequest.PullRequestInfo.Title) &&
-			hookCommon.IsSkipBuildByCommitMessage(pullRequest.PullRequestInfo.Body),
+		SkippedByPrDescription: !hookCommon.ContainsSkipInstruction(pullRequest.PullRequestInfo.Title) &&
+			hookCommon.ContainsSkipInstruction(pullRequest.PullRequestInfo.Body),
 	}
 }
 
@@ -472,8 +472,8 @@ func transformIssueCommentEvent(eventModel IssueCommentEventModel) hookCommon.Tr
 		TriggerAPIParams: []bitriseapi.TriggerAPIParamsModel{
 			result,
 		},
-		SkippedByPrDescription: !hookCommon.IsSkipBuildByCommitMessage(issue.Title) &&
-			hookCommon.IsSkipBuildByCommitMessage(issue.Body),
+		SkippedByPrDescription: !hookCommon.ContainsSkipInstruction(issue.Title) &&
+			hookCommon.ContainsSkipInstruction(issue.Body),
 	}
 }
 

--- a/service/hook/gitlab/gitlab.go
+++ b/service/hook/gitlab/gitlab.go
@@ -624,8 +624,8 @@ func transformMergeRequest(
 				TriggeredBy: hookCommon.GenerateTriggeredBy(ProviderID, user.Username),
 			},
 		},
-		SkippedByPrDescription: !hookCommon.IsSkipBuildByCommitMessage(mergeRequest.Title) &&
-			hookCommon.IsSkipBuildByCommitMessage(mergeRequest.Description),
+		SkippedByPrDescription: !hookCommon.ContainsSkipInstruction(mergeRequest.Title) &&
+			hookCommon.ContainsSkipInstruction(mergeRequest.Description),
 	}
 }
 


### PR DESCRIPTION
This PR extends to support for skip instructions to PR comments (which can be used to trigger builds). This is to provide a better experience with various automated tools that create comments (review tools, AI agents etc.)
